### PR TITLE
Explicitly pass in constituent array to aerosol model

### DIFF
--- a/src/chemistry/utils/modal_aero_calcsize.F90
+++ b/src/chemistry/utils/modal_aero_calcsize.F90
@@ -75,10 +75,10 @@ subroutine modal_aero_calcsize_reg()
   use rad_constituents, only: rad_cnst_get_info
 
   integer :: nmodes
-  
+
   call rad_cnst_get_info(0, nmodes=nmodes)
 
-  call pbuf_add_field('DGNUM', 'global',  dtype_r8, (/pcols, pver, nmodes/), dgnum_idx)    
+  call pbuf_add_field('DGNUM', 'global',  dtype_r8, (/pcols, pver, nmodes/), dgnum_idx)
 
   call pbuf_add_field('HYGRO',     'phys_pkg', dtype_r8, (/pcols,pver,nmodes/), hygro_idx)
   call pbuf_add_field('DRYVOL',    'phys_pkg', dtype_r8, (/pcols,pver,nmodes/), dryvol_idx)
@@ -155,7 +155,7 @@ subroutine modal_aero_calcsize_init(pbuf2d)
    if ( .not. do_adjust_default ) return
 
    !  define history fields for number-adjust source-sink for all modes
-   do n = 1, ntot_amode 
+   do n = 1, ntot_amode
       if (mprognum_amode(n) <= 0) cycle
 
       do jac = 1, 2
@@ -198,7 +198,7 @@ subroutine modal_aero_calcsize_init(pbuf2d)
    ! define history fields for aitken-accum transfer
    do iq = 1, nspecfrm_renamexf(ipair)
 
-      ! jac=1 does interstitial ("_a"); jac=2 does activated ("_c"); 
+      ! jac=1 does interstitial ("_a"); jac=2 does activated ("_c");
       do jac = 1, 2
 
          ! the lspecfrma_renamexf (and lspecfrmc_renamexf) are aitken species
@@ -269,7 +269,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
    !-----------------------------------------------------------------------
    !
-   ! Calculates aerosol size distribution parameters 
+   ! Calculates aerosol size distribution parameters
    !    mprognum_amode >  0
    !       calculate Dgnum from mass, number, and fixed sigmag
    !    mprognum_amode <= 0
@@ -306,7 +306,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    real(r8), pointer :: t(:,:)      ! Temperature in Kelvin
    real(r8), pointer :: pmid(:,:)   ! pressure at model levels (Pa)
    real(r8), pointer :: pdel(:,:)   ! pressure thickness of levels
-   real(r8), pointer :: q(:,:,:)    ! Tracer MR array 
+   real(r8), pointer :: q(:,:,:)    ! Tracer MR array
 
    logical,  pointer :: dotend(:)   ! flag for doing tendency
    real(r8), pointer :: dqdt(:,:,:) ! TMR tendency array
@@ -316,7 +316,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    integer  :: i, icol_diag, iduma, ipair, iq
    integer  :: ixfer_acc2ait, ixfer_ait2acc
    integer  :: ixfer_acc2ait_sv(pcols,pver), ixfer_ait2acc_sv(pcols,pver)
-   integer  :: j, jac, jsrflx, k 
+   integer  :: j, jac, jsrflx, k
    integer  :: l, l1, la, lc, lna, lnc, lsfrm, lstoo
    integer  :: n, nacc, nait
 
@@ -338,12 +338,12 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    real(r8) :: dqqcwdt(pcols,pver,pcnst)     ! cloudborne TMR tendency array
    real(r8) :: drv_a, drv_c, drv_t           ! dry volume (cm3/mol_air)
    real(r8) :: drv_t0
-   real(r8) :: drv_a_noxf, drv_c_noxf, drv_t_noxf 
+   real(r8) :: drv_a_noxf, drv_c_noxf, drv_t_noxf
    real(r8) :: drv_a_acc, drv_c_acc
    real(r8) :: drv_a_accsv(pcols,pver), drv_c_accsv(pcols,pver)
    real(r8) :: drv_a_aitsv(pcols,pver), drv_c_aitsv(pcols,pver)
    real(r8) :: drv_a_sv(pcols,pver,ntot_amode), drv_c_sv(pcols,pver,ntot_amode)
-   real(r8) :: dryvol_a(pcols,pver)          ! interstital aerosol dry 
+   real(r8) :: dryvol_a(pcols,pver)          ! interstital aerosol dry
    ! volume (cm^3/mol_air)
    real(r8) :: dryvol_c(pcols,pver)          ! activated aerosol dry volume
    real(r8) :: duma, dumb, dumc, dumd        ! work variables
@@ -361,13 +361,13 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    real(r8) :: num_a_accsv(pcols,pver), num_c_accsv(pcols,pver)
    real(r8) :: num_a_aitsv(pcols,pver), num_c_aitsv(pcols,pver)
    real(r8) :: num_a_sv(pcols,pver,ntot_amode), num_c_sv(pcols,pver,ntot_amode)
-   real(r8) :: pdel_fac                      ! 
+   real(r8) :: pdel_fac                      !
    real(r8) :: tadj                          ! adjustment time scale
    real(r8) :: tadjinv                       ! 1/tadj
    real(r8) :: v2ncur_a(pcols,pver,ntot_amode)
    real(r8) :: v2ncur_c(pcols,pver,ntot_amode)
    real(r8) :: v2nyy, v2nxx, v2nzz           ! voltonumblo/hi of current mode
-   real(r8) :: v2nyyrl, v2nxxrl              ! relaxed voltonumblo/hi 
+   real(r8) :: v2nyyrl, v2nxxrl              ! relaxed voltonumblo/hi
    real(r8) :: xfercoef
    real(r8) :: xfercoef_num_acc2ait, xfercoef_vol_acc2ait
    real(r8) :: xfercoef_num_ait2acc, xfercoef_vol_ait2acc
@@ -378,11 +378,11 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    integer, parameter :: nsrflx = 4    ! last dimension of qsrflx
    real(r8) :: qsrflx(pcols,pcnst,nsrflx,2)
    ! process-specific column tracer tendencies
-   ! 3rd index -- 
+   ! 3rd index --
    !    1="standard" number adjust gain;
    !    2="standard" number adjust loss;
    !    3=aitken-->accum renaming; 4=accum-->aitken)
-   ! 4th index -- 
+   ! 4th index --
    !    1="a" species; 2="c" species
    !-----------------------------------------------------------------------
 
@@ -405,7 +405,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    pmid => state%pmid
    pdel => state%pdel
    q    => state%q
- 
+
    dotend => ptend%lq
    dqdt   => ptend%q
 
@@ -428,7 +428,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
    fracadj = deltat*tadjinv
    fracadj = max( 0.0_r8, min( 1.0_r8, fracadj ) )
 
-   
+
    !
    !
    ! the "do 40000" loop does the original (pre jan-2006)
@@ -454,7 +454,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
          end do
       end do
 
-      ! compute dry volume mixrats = 
+      ! compute dry volume mixrats =
       !      sum_over_components{ component_mass mixrat / density }
       do l1 = 1, nspec_amode(n)
          ! need qmass*dummwdens = (kg/kg-air) * [1/(kg/m3)] = m3/kg-air
@@ -524,12 +524,12 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
          !    number towards the primary bounds.
          !
          ! note
-         !    v2nyy = voltonumblo_amode is proportional to dgnumlo**(-3), 
+         !    v2nyy = voltonumblo_amode is proportional to dgnumlo**(-3),
          !            and produces the maximum allowed number for a given volume
-         !    v2nxx = voltonumbhi_amode is proportional to dgnumhi**(-3), 
+         !    v2nxx = voltonumbhi_amode is proportional to dgnumhi**(-3),
          !            and produces the minimum allowed number for a given volume
-         !    v2nxxrl and v2nyyrl are their "relaxed" equivalents.  
-         !            Setting frelaxadj=27=3**3 means that 
+         !    v2nxxrl and v2nyyrl are their "relaxed" equivalents.
+         !            Setting frelaxadj=27=3**3 means that
          !            dgnumlo_relaxed = dgnumlo/3 and dgnumhi_relaxed = dgnumhi*3
          !
          ! if do_aitacc_transfer is .true., then
@@ -540,7 +540,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
          !OLD  however, do not change the v2nyyrl/v2nxxrl so that
          !OLD      the interstitial<-->activated adjustment is not changed
          !NEW  also change the v2nyyrl/v2nxxrl so that
-         !NEW      the interstitial<-->activated adjustment is turned off 
+         !NEW      the interstitial<-->activated adjustment is turned off
          !
       end if
       frelaxadj = 27.0_r8
@@ -630,7 +630,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                      num_c2 = max( drv_c*v2nxxrl, min( drv_c*v2nyyrl,   &
                         num_c1-delnum_a2 ) )
                   end if
-                  ! step3:  num_a,c2 --> num_a,c3 applies stricter bounds to the 
+                  ! step3:  num_a,c2 --> num_a,c3 applies stricter bounds to the
                   !    combined/total number
                   drv_t = drv_a + drv_c
                   num_t2 = num_a2 + num_c2
@@ -738,8 +738,8 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
    !
    !
-   ! the following section (from here to label 49000) 
-   !    does aitken <--> accum mode transfer 
+   ! the following section (from here to label 49000)
+   !    does aitken <--> accum mode transfer
    !
    ! when the aitken mode mean size is too big, the largest
    !    aitken particles are transferred into the accum mode
@@ -852,8 +852,8 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
             ! compute accum --> aitken transfer rates
             ! accum may have some species (seasalt, dust, poa, lll) that are
             !    not in aitken mode
-            ! so first divide the accum drv & num into not-transferred (noxf) species 
-            !    and transferred species, and use the transferred-species 
+            ! so first divide the accum drv & num into not-transferred (noxf) species
+            !    and transferred species, and use the transferred-species
             !    portion in what follows
             ixfer_acc2ait = 0
             xfercoef_num_acc2ait = 0.0_r8
@@ -874,7 +874,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                         drv_a_noxf = drv_a_noxf    &
                            + max(0.0_r8,q(i,k,la))*dummwdens
                         lc = lmassptrcw_amode(l1,nacc)
-                        
+
                         fldcw => qqcw_get_field(pbuf,lmassptrcw_amode(l1,nacc),lchnk)
                         drv_c_noxf = drv_c_noxf    &
                            + max(0.0_r8,fldcw(i,k))*dummwdens
@@ -967,7 +967,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                      dgncur_a(i,k,n) = dgnum_amode(n)
                      v2ncur_a(i,k,n) = voltonumb_amode(n)
                   end if
-                  
+
                   if (drv_c > 0.0_r8) then
                      if (num_c <= drv_c*voltonumbhi_amode(n)) then
                         dgncur_c(i,k,n) = dgnumhi_amode(n)
@@ -990,7 +990,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                !
                ! compute tendency amounts for aitken <--> accum transfer
                !
-               
+
                if ( masterproc ) then
                   if (idiagaa > 0) then
                      do j = 1, 2
@@ -1023,7 +1023,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
                idiagaa = -1
 
 
-               ! j=1 does aitken-->accum; j=2 does accum-->aitken 
+               ! j=1 does aitken-->accum; j=2 does accum-->aitken
                do  j = 1, 2
 
                   if ((j .eq. 1 .and. ixfer_ait2acc > 0) .or. &
@@ -1038,7 +1038,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
                      do  iq = 1, nspecfrm_renamexf(ipair)
 
-                        ! jac=1 does interstitial ("_a"); jac=2 does activated ("_c"); 
+                        ! jac=1 does interstitial ("_a"); jac=2 does activated ("_c");
                         do  jac = 1, 2
 
                            ! the lspecfrma_renamexf (and lspecfrmc_renamexf) are aitken species
@@ -1096,7 +1096,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
       end do
 
 
-   end if  !  do_aitacc_transfer 
+   end if  !  do_aitacc_transfer
    lsfrm = -123456789   ! executable statement for debugging
 
 
@@ -1122,8 +1122,8 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
    ! history fields for number-adjust source-sink for all modes
    if ( .not. do_adjust ) return
-   
-   do n = 1, ntot_amode 
+
+   do n = 1, ntot_amode
       if (mprognum_amode(n) <= 0) cycle
 
       do jac = 1, 2
@@ -1136,7 +1136,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
          end if
          fieldname = trim(tmpnamea) // '_sfcsiz1'
          call outfld( fieldname, qsrflx(:,l,1,jac), pcols, lchnk)
-         
+
          fieldname = trim(tmpnamea) // '_sfcsiz2'
          call outfld( fieldname, qsrflx(:,l,2,jac), pcols, lchnk)
       end do   ! jac = ...
@@ -1149,7 +1149,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 
    do iq = 1, nspecfrm_renamexf(ipair)
 
-      ! jac=1 does interstitial ("_a"); jac=2 does activated ("_c"); 
+      ! jac=1 does interstitial ("_a"); jac=2 does activated ("_c");
       do jac = 1, 2
 
          ! the lspecfrma_renamexf (and lspecfrmc_renamexf) are aitken species
@@ -1162,7 +1162,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
             lstoo = lspectooc_renamexf(iq,ipair)
          end if
          if ((lsfrm <= 0) .or. (lstoo <= 0)) cycle
-         
+
          if (jac .eq. 1) then
             tmpnamea = cnst_name(lsfrm)
             tmpnameb = cnst_name(lstoo)
@@ -1192,7 +1192,7 @@ subroutine modal_aero_calcsize_sub(state, ptend, deltat, pbuf, do_adjust_in, &
 #endif
 
 end subroutine modal_aero_calcsize_sub
- 
+
 
 !----------------------------------------------------------------------
 
@@ -1202,7 +1202,7 @@ subroutine modal_aero_calcsize_diag(state, pbuf, list_idx_in, dgnum_m, &
 
    !-----------------------------------------------------------------------
    !
-   ! Calculate aerosol size distribution parameters 
+   ! Calculate aerosol size distribution parameters
    !
    ! ***N.B.*** DGNUM for the modes in the climate list are put directly into
    !            the physics buffer.  For diagnostic list calculations use the
@@ -1339,17 +1339,17 @@ subroutine modal_aero_calcsize_diag(state, pbuf, list_idx_in, dgnum_m, &
                                    sigmag=sigmag)
 
       ! get mode number mixing ratio
-      call rad_cnst_get_mode_num(list_idx, n, 'a', state, pbuf, mode_num)
+      call rad_cnst_get_mode_num(list_idx, n, 'a', state%q, pbuf, mode_num)
 
       dgncur_a(:,:) = dgnum
       dryvol_a(:,:) = 0.0_r8
 
-      ! compute dry volume mixrats = 
+      ! compute dry volume mixrats =
       !      sum_over_components{ component_mass mixrat / density }
       call rad_cnst_get_info(list_idx, n, nspec=nspec)
       do l1 = 1, nspec
 
-         call rad_cnst_get_aer_mmr(list_idx, n, l1, 'a', state, pbuf, specmmr)
+         call rad_cnst_get_aer_mmr(list_idx, n, l1, 'a', state%q, pbuf, specmmr)
          call rad_cnst_get_aer_props(list_idx, n, l1, density_aer=specdens)
 
          ! need qmass*dummwdens = (kg/kg-air) * [1/(kg/m3)] = m3/kg-air
@@ -1417,7 +1417,7 @@ subroutine modal_aero_calcdry(state, pbuf, list_idx_in, dgnumdry_m, hygro_m, dry
    real(r8), pointer :: maer(:,:)        ! aerosol wet mass MR (including water) (kg/kg-air)
    real(r8), pointer :: hygro(:,:,:)     ! volume-weighted mean hygroscopicity (--)
    real(r8), pointer :: dryvol(:,:,:)    ! single-particle-mean dry volume (m3)
-   real(r8), pointer :: dryrad(:,:,:)    ! dry volume mean radius of aerosol (m) 
+   real(r8), pointer :: dryrad(:,:,:)    ! dry volume mean radius of aerosol (m)
    real(r8), pointer :: drymass(:,:,:)   ! single-particle-mean dry mass  (kg)
    real(r8), pointer :: so4dryvol(:,:,:) ! single-particle-mean so4 dry volume (m3)
    real(r8), pointer :: naer(:,:,:)      ! aerosol number MR (bounded!) (#/kg-air)
@@ -1507,7 +1507,7 @@ subroutine modal_aero_calcdry(state, pbuf, list_idx_in, dgnumdry_m, hygro_m, dry
       do l = 1, nspec
 
          ! get species interstitial mixing ratio ('a')
-         call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state, pbuf, raer)
+         call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state%q, pbuf, raer)
          call rad_cnst_get_aer_props(list_idx, m, l, density_aer=specdens, &
                                      hygro_aer=spechygro, spectype=spectype)
 

--- a/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -60,13 +60,13 @@ subroutine modal_aero_wateruptake_reg()
   use rad_constituents, only: rad_cnst_get_info
 
    integer :: nmodes
-   
+
    call rad_cnst_get_info(0, nmodes=nmodes)
    call pbuf_add_field('DGNUMWET',   'global',  dtype_r8, (/pcols, pver, nmodes/), dgnumwet_idx)
    call pbuf_add_field('WETDENS_AP', 'physpkg', dtype_r8, (/pcols, pver, nmodes/), wetdens_ap_idx)
 
    ! 1st order rate for direct conversion of strat. cloud water to precip (1/s)
-   call pbuf_add_field('QAERWAT',    'physpkg', dtype_r8, (/pcols, pver, nmodes/), qaerwat_idx)  
+   call pbuf_add_field('QAERWAT',    'physpkg', dtype_r8, (/pcols, pver, nmodes/), qaerwat_idx)
 
    if (modal_strat_sulfate) then
       call pbuf_add_field('MAMH2SO4EQ', 'global',  dtype_r8, (/pcols, pver, nmodes/), sulfeq_idx)
@@ -93,16 +93,16 @@ subroutine modal_aero_wateruptake_init(pbuf2d)
    !----------------------------------------------------------------------------
 
    real_nan = nan
-    
-   cld_idx        = pbuf_get_index('CLD')    
-   dgnum_idx      = pbuf_get_index('DGNUM')    
 
-   hygro_idx      = pbuf_get_index('HYGRO')    
-   dryvol_idx     = pbuf_get_index('DRYVOL')    
-   dryrad_idx     = pbuf_get_index('DRYRAD')    
-   drymass_idx    = pbuf_get_index('DRYMASS')    
-   so4dryvol_idx  = pbuf_get_index('SO4DRYVOL')    
-   naer_idx       = pbuf_get_index('NAER')    
+   cld_idx        = pbuf_get_index('CLD')
+   dgnum_idx      = pbuf_get_index('DGNUM')
+
+   hygro_idx      = pbuf_get_index('HYGRO')
+   dryvol_idx     = pbuf_get_index('DRYVOL')
+   dryrad_idx     = pbuf_get_index('DRYRAD')
+   drymass_idx    = pbuf_get_index('DRYMASS')
+   so4dryvol_idx  = pbuf_get_index('SO4DRYVOL')
+   naer_idx       = pbuf_get_index('NAER')
 
    ! assume for now that will compute wateruptake for climate list modes only
 
@@ -116,18 +116,18 @@ subroutine modal_aero_wateruptake_init(pbuf2d)
          'wet dgnum, interstitial, mode '//trnum(2:3))
       call addfld('wat_a'//trnum(3:3),  (/ 'lev' /), 'A', 'm', &
          'aerosol water, interstitial, mode '//trnum(2:3))
-      
+
       ! determine default variables
       call phys_getopts(history_aerosol_out = history_aerosol)
 
-      if (history_aerosol) then  
+      if (history_aerosol) then
          call add_default('dgnd_a'//trnum(2:3), 1, ' ')
          call add_default('dgnw_a'//trnum(2:3), 1, ' ')
          call add_default('wat_a'//trnum(3:3),  1, ' ')
       endif
 
    end do
-   
+
    call addfld('PM25',     (/ 'lev' /), 'A', 'kg/m3', 'PM2.5 concentration')
    call addfld('PM25_SRF', horiz_only,  'A', 'kg/m3', 'surface PM2.5 concentration')
 
@@ -135,7 +135,7 @@ subroutine modal_aero_wateruptake_init(pbuf2d)
       ! initialize fields in physics buffer
       call pbuf_set_field(pbuf2d, dgnumwet_idx, 0.0_r8)
       if (modal_strat_sulfate) then
-      ! initialize fields in physics buffer to NaN (not a number) 
+      ! initialize fields in physics buffer to NaN (not a number)
       ! so model will crash if used before initialization
          call pbuf_set_field(pbuf2d, sulfeq_idx, real_nan)
       endif
@@ -223,7 +223,7 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    real(r8), pointer :: sulfeq(:,:,:) ! H2SO4 equilibrium mixing ratios over particles (mol/mol)
    real(r8), allocatable :: wtpct(:,:,:)  ! sulfate aerosol composition, weight % H2SO4
    real(r8), allocatable :: sulden(:,:,:) ! sulfate aerosol mass density (g/cm3)
-   
+
    real(r8) :: specdens, so4specdens
    real(r8) :: sigmag
    real(r8), allocatable :: alnsg(:)
@@ -233,8 +233,8 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    real(r8) :: es(pcols)             ! saturation vapor pressure
    real(r8) :: qs(pcols)             ! saturation specific humidity
 
-   real(r8) :: pm25(pcols,pver)      ! PM2.5 diagnostics     
-   real(r8) :: rhoair(pcols,pver) 
+   real(r8) :: pm25(pcols,pver)      ! PM2.5 diagnostics
+   real(r8) :: rhoair(pcols,pver)
 
    character(len=3) :: trnum       ! used to hold mode number (as characters)
    character(len=32) :: spectype
@@ -271,7 +271,7 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    call rad_cnst_get_info(list_idx, nmodes=nmodes)
 
    if (modal_strat_sulfate) then
-     call pbuf_get_field(pbuf,  sulfeq_idx, sulfeq ) 
+     call pbuf_get_field(pbuf,  sulfeq_idx, sulfeq )
    endif
 
    allocate( &
@@ -339,9 +339,9 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
       do l = 1, nspec
 
          ! accumulate the aerosol masses of each mode
-         call rad_cnst_get_aer_mmr(0, m, l, 'a', state, pbuf, raer)
+         call rad_cnst_get_aer_mmr(0, m, l, 'a', state%q, pbuf, raer)
          maer(:ncol,:,m)= maer(:ncol,:,m) + raer(:ncol,:)
-            
+
          ! get species interstitial mixing ratio ('a')
          call rad_cnst_get_aer_props(list_idx, m, l, density_aer=specdens, &
                                      spectype=spectype)
@@ -367,24 +367,24 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
                                                qh2so4_equilib, wtpct_mode, sulden_mode )
                sulfeq(i,k,m)  = qh2so4_equilib
                wtpct(i,k,m)   = wtpct_mode
-               sulden(i,k,m)  = sulden_mode                        
+               sulden(i,k,m)  = sulden_mode
             end do    ! i = 1, ncol
          end do    ! k = top_lev, pver
- 
+
           fieldname = ' '
           write(fieldname,fmt='(a,i1)') 'wtpct_a',m
           call outfld(fieldname,wtpct(1:ncol,1:pver,m), ncol, lchnk )
- 
+
           fieldname = ' '
           write(fieldname,fmt='(a,i1)') 'sulfeq_a',m
           call outfld(fieldname,sulfeq(1:ncol,1:pver,m), ncol, lchnk )
- 
+
           fieldname = ' '
           write(fieldname,fmt='(a,i1)') 'sulden_a',m
           call outfld(fieldname,sulden(1:ncol,1:pver,m), ncol, lchnk )
- 
+
        end if
-      
+
     end do    ! m = 1, nmodes
 
    ! relative humidity calc
@@ -483,7 +483,7 @@ subroutine modal_aero_wateruptake_sub( &
 !
 !-----------------------------------------------------------------------
 
-   
+
    ! Arguments
    integer, intent(in)  :: ncol                    ! number of columns
    integer, intent(in)  :: nmodes
@@ -650,13 +650,13 @@ end subroutine modal_aero_wateruptake_sub
            do n=1,4
               xr=real(cx4(n,i))
               xi=aimag(cx4(n,i))
-              if(abs(xi).gt.abs(xr)*eps) cycle  
-              if(xr.gt.r(i)) cycle  
-              if(xr.lt.rdry(i)*(1._r8-eps)) cycle  
-              if(xr.ne.xr) cycle  
+              if(abs(xi).gt.abs(xr)*eps) cycle
+              if(xr.gt.r(i)) cycle
+              if(xr.lt.rdry(i)*(1._r8-eps)) cycle
+              if(xr.ne.xr) cycle
               r(i)=xr
               nsol=n
-           end do  
+           end do
            if(nsol.eq.0)then
               write(iulog,*)   &
                'ccm kohlerc - no real(r8) solution found (quartic)'
@@ -684,13 +684,13 @@ end subroutine modal_aero_wateruptake_sub
               do n=1,3
                  xr=real(cx3(n,i))
                  xi=aimag(cx3(n,i))
-                 if(abs(xi).gt.abs(xr)*eps) cycle  
-                 if(xr.gt.r(i)) cycle  
-                 if(xr.lt.rdry(i)*(1._r8-eps)) cycle  
-                 if(xr.ne.xr) cycle  
+                 if(abs(xi).gt.abs(xr)*eps) cycle
+                 if(xr.gt.r(i)) cycle
+                 if(xr.lt.rdry(i)*(1._r8-eps)) cycle
+                 if(xr.ne.xr) cycle
                  r(i)=xr
                  nsol=n
-              end do  
+              end do
               if(nsol.eq.0)then
                  write(iulog,*)   &
                   'ccm kohlerc - no real(r8) solution found (cubic)'
@@ -844,11 +844,11 @@ end subroutine modal_aero_wateruptake_sub
       real(r8), intent(out) :: qh2so4_equilib  ! h2so4 saturation mixing ratios over the particles (mol/mol)
       real(r8), intent(out) :: wtpct           ! sulfate composition, weight % H2SO4
       real(r8), intent(out) :: sulden          ! sulfate aerosol mass density (g/cm3)
-      
+
       ! Local declarations
       real(r8)            :: qh2o_kelvin ! water vapor specific humidity adjusted for Kelvin effect (kg/kg)
       real(r8)            :: wtpct_flat  ! sulfate composition over a flat surface, weight % H2SO4
-      real(r8)            :: fk1, fk4, fk4_1, fk4_2 
+      real(r8)            :: fk1, fk4, fk4_1, fk4_2
       real(r8)            :: factor_kulm                     ! Kulmala correction terms
       real(r8)            :: en, t, sig1, sig2, frac, surf_tens, surf_tens_mode, dsigma_dwt
       real(r8)            :: den1, den2, sulfate_density, drho_dwt
@@ -858,7 +858,7 @@ end subroutine modal_aero_wateruptake_sub
       real(r8), parameter :: t_crit_kulm = 905._r8           !  Critical temperature = 1.5 * Boiling point
       real(r8), parameter :: fk0         = -10156._r8 / t0_kulm + 16.259_r8   !  Log(Kulmala correction factor)
       real(r8), parameter :: fk2         = 1._r8 / t0_kulm
-      real(r8), parameter :: fk3         = 0.38_r8 / (t_crit_kulm - t0_kulm)   
+      real(r8), parameter :: fk3         = 0.38_r8 / (t_crit_kulm - t0_kulm)
       real(r8), parameter :: RGAS = 8.31430e+07_r8           ! ideal gas constant (erg/mol/K)
       real(r8), parameter :: wtmol_h2so4 =  98.078479_r8     ! molecular weight of sulphuric acid
       real(r8), parameter :: wtmol_h2o   =  18.015280_r8     ! molecular weight of water vapor
@@ -868,7 +868,7 @@ end subroutine modal_aero_wateruptake_sub
       real(r8)            :: stwtp(15), stc0(15), stc1(15)
       integer             :: i, k
 
-        
+
       data stwtp/0._r8, 23.8141_r8, 38.0279_r8, 40.6856_r8, 45.335_r8, 52.9305_r8, &
          56.2735_r8, 59.8557_r8, 66.2364_r8, 73.103_r8, 79.432_r8, 85.9195_r8, &
          91.7444_r8, 97.6687_r8, 100._r8/
@@ -881,14 +881,14 @@ end subroutine modal_aero_wateruptake_sub
          -0.0746702_r8, -0.0522399_r8, -0.0407773_r8, -0.0357946_r8, -0.0317062_r8,   &
          -0.025825_r8, -0.0267212_r8, -0.0269204_r8, -0.0276187_r8, -0.0302094_r8,    &
          -0.0303081_r8 /
-           
-       
+
+
       data dnwtp / 0._r8, 1._r8, 5._r8, 10._r8, 20._r8, 25._r8, 30._r8, 35._r8, 40._r8,  &
          41._r8, 45._r8, 50._r8, 53._r8, 55._r8, 56._r8, 60._r8, 65._r8, 66._r8, 70._r8, &
          72._r8, 73._r8, 74._r8, 75._r8, 76._r8, 78._r8, 79._r8, 80._r8, 81._r8, 82._r8, &
          83._r8, 84._r8, 85._r8, 86._r8, 87._r8, 88._r8, 89._r8, 90._r8, 91._r8, 92._r8, &
          93._r8, 94._r8, 95._r8, 96._r8, 97._r8, 98._r8, 100._r8 /
-         
+
       data dnc0 / 1._r8, 1.13185_r8, 1.17171_r8, 1.22164_r8, 1.3219_r8, 1.37209_r8,         &
          1.42185_r8, 1.4705_r8, 1.51767_r8, 1.52731_r8, 1.56584_r8, 1.61834_r8, 1.65191_r8, &
          1.6752_r8, 1.68708_r8, 1.7356_r8, 1.7997_r8, 1.81271_r8, 1.86696_r8, 1.89491_r8,   &
@@ -896,7 +896,7 @@ end subroutine modal_aero_wateruptake_sub
          2.03234_r8, 2.04716_r8, 2.06082_r8, 2.07363_r8, 2.08461_r8, 2.09386_r8, 2.10143_r8,&
          2.10764_r8, 2.11283_r8, 2.11671_r8, 2.11938_r8, 2.12125_r8, 2.1219_r8, 2.12723_r8, &
          2.12654_r8, 2.12621_r8, 2.12561_r8, 2.12494_r8, 2.12093_r8 /
-         
+
       data dnc1 / 0._r8,  -0.000435022_r8, -0.000479481_r8, -0.000531558_r8, -0.000622448_r8, &
          -0.000660866_r8, -0.000693492_r8, -0.000718251_r8, -0.000732869_r8, -0.000735755_r8, &
          -0.000744294_r8, -0.000761493_r8, -0.000774238_r8, -0.00078392_r8, -0.000788939_r8,  &
@@ -906,17 +906,17 @@ end subroutine modal_aero_wateruptake_sub
          -0.00103757_r8, -0.00104337_r8, -0.00104563_r8, -0.00104458_r8, -0.00104144_r8,      &
          -0.00103719_r8, -0.00103089_r8, -0.00102262_r8, -0.00101355_r8, -0.00100249_r8,      &
          -0.00100934_r8, -0.000998299_r8, -0.000990961_r8, -0.000985845_r8, -0.000984529_r8,  &
-         -0.000989315_r8 /  
+         -0.000989315_r8 /
 
       ! Saturation vapor pressure of sulfuric acid
-      !  
+      !
       ! Limit extrapolation at extreme temperatures
       t=min(max(temp,140._r8),450._r8)
-      
+
       !!  Calculate the weight % H2SO4 composition of sulfate
       call calc_h2so4_wtpct(t, pres, qh2o, wtpct_flat)
-                  
-      !!  Calculate surface tension (erg/cm2) of sulfate of 
+
+      !!  Calculate surface tension (erg/cm2) of sulfate of
       !!  different compositions as a linear function of temperature.
       i = 2 ! minimum wt% is 29.517
       do while (wtpct_flat.gt.stwtp(i))
@@ -924,11 +924,11 @@ end subroutine modal_aero_wateruptake_sub
       end do
       sig1 = stc0(i-1) + stc1(i-1) * t
       sig2 = stc0(i)   + stc1(i) * t
-      ! calculate derivative needed later for kelvin factor for h2o      
+      ! calculate derivative needed later for kelvin factor for h2o
       dsigma_dwt = (sig2-sig1) / (stwtp(i)-stwtp(i-1))
-      surf_tens = sig1 + dsigma_dwt*(wtpct_flat-stwtp(i))    
-      
-      !!  Calculate density (g/cm3) of sulfate of 
+      surf_tens = sig1 + dsigma_dwt*(wtpct_flat-stwtp(i))
+
+      !!  Calculate density (g/cm3) of sulfate of
       !!  different compositions as a linear function of temperature.
       i = 6 ! minimum wt% is 29.517
       do while (wtpct_flat .gt. dnwtp(i))
@@ -936,7 +936,7 @@ end subroutine modal_aero_wateruptake_sub
       end do
       den1 = dnc0(i-1) + dnc1(i-1) * t
       den2 = dnc0(i)   + dnc1(i) * t
-      ! Calculate derivative needed later for Kelvin factor for H2O      
+      ! Calculate derivative needed later for Kelvin factor for H2O
       drho_dwt = (den2-den1) / (dnwtp(i)-dnwtp(i-1))
       sulfate_density = den1 + drho_dwt * (wtpct_flat-dnwtp(i-1))
 
@@ -947,7 +947,7 @@ end subroutine modal_aero_wateruptake_sub
          sulfate_density - 3._r8 * wtpct_flat * dsigma_dwt / (2._r8*surf_tens)
 
       rkelvinH2O_a = 2._r8 * wtmol_h2so4 * surf_tens / &
-           (sulfate_density * RGAS * t * r)     
+           (sulfate_density * RGAS * t * r)
 
       rkelvinH2O = exp (rkelvinH2O_a*rkelvinH2O_b)
 
@@ -961,7 +961,7 @@ end subroutine modal_aero_wateruptake_sub
       en = 4.184_r8 * (23624.8_r8 - 1.14208e8_r8 / ((wtpct - 105.318_r8)**2 + 4798.69_r8))
       en = max(en, 0.0_r8)
 
-      !!  Calculate surface tension (erg/cm2) of sulfate of 
+      !!  Calculate surface tension (erg/cm2) of sulfate of
       !!  different compositions as a linear function of temperature.
       i = 2 ! minimum wt% is 29.517
       do while (wtpct.gt.stwtp(i))
@@ -970,9 +970,9 @@ end subroutine modal_aero_wateruptake_sub
       sig1=stc0(i-1)+stc1(i-1)*t
       sig2=stc0(i)+stc1(i)*t
       frac=(stwtp(i)-wtpct)/(stwtp(i)-stwtp(i-1))
-      surf_tens_mode=sig1*frac+sig2*(1.0_r8-frac)     
+      surf_tens_mode=sig1*frac+sig2*(1.0_r8-frac)
 
-      !!  Calculate density (g/cm3) of sulfate of 
+      !!  Calculate density (g/cm3) of sulfate of
       !!  different compositions as a linear function of temperature.
       i = 6 ! minimum wt% is 29.517
       do while (wtpct .gt. dnwtp(i))
@@ -1004,7 +1004,7 @@ end subroutine modal_aero_wateruptake_sub
       sulfequil = exp(sulfequil)
 
       ! Convert atmospheres ==> Pa
-      sulfequil = sulfequil * 1.01325e5_r8  
+      sulfequil = sulfequil * 1.01325e5_r8
 
       ! Convert Pa ==> mol/mol
       sulfequil = sulfequil / pres
@@ -1013,7 +1013,7 @@ end subroutine modal_aero_wateruptake_sub
       ! (g/mol)*(erg/cm2)/(K * g/cm3 * erg/mol/K) = cm
       akelvin = 2._r8 * wtmol_h2so4 * surf_tens_mode / (t * sulden * RGAS)
 
-      expon = akelvin / r  ! divide by mode radius (cm) 
+      expon = akelvin / r  ! divide by mode radius (cm)
       expon = max(-100._r8, expon)
       expon = min(100._r8, expon)
       akas = exp( expon )
@@ -1025,12 +1025,12 @@ end subroutine modal_aero_wateruptake_sub
 
 !----------------------------------------------------------------------
       subroutine calc_h2so4_wtpct( temp, pres, qh2o, wtpct )
-      
-  !!  This function calculates the weight % H2SO4 composition of 
+
+  !!  This function calculates the weight % H2SO4 composition of
   !!  sulfate aerosol, using Tabazadeh et. al. (GRL, 1931, 1997).
   !!  Rated for T=185-260K, activity=0.01-1.0
   !!
-  !!  Argument list input:   
+  !!  Argument list input:
   !!    temp = temperature (K)
   !!    pres = atmospheric pressure (Pa)
   !!    qh2o = water specific humidity (kg/kg)
@@ -1042,14 +1042,14 @@ end subroutine modal_aero_wateruptake_sub
   !! @ version October 2013
 
       use wv_saturation, only: qsat_water
-      
+
       implicit none
 
       real(r8), intent(in)  :: temp  ! temperature (K)
       real(r8), intent(in)  :: pres  ! pressure (Pa)
       real(r8), intent(in)  :: qh2o  ! water vapor specific humidity (kg/kg)
       real(r8), intent(out) :: wtpct ! sulfate weight % H2SO4 composition
-      
+
       ! Local declarations
       real(r8)            :: atab1,btab1,ctab1,dtab1,atab2,btab2,ctab2,dtab2
       real(r8)            :: contl, conth, contt, conwtp
@@ -1059,17 +1059,17 @@ end subroutine modal_aero_wateruptake_sub
 
       ! calculate saturation specific humidity over pure water, qs (kg/kg)
       call qsat_water(temp, pres, es, qs)
-      
+
       !  Activity = water specific humidity (kg/kg) / equilibrium water (kg/kg)
       activ = qh2o/qs
-       
+
       if (activ.lt.0.05_r8) then
         activ = max(activ,1.e-6_r8)    ! restrict minimum activity
-        atab1 	= 12.37208932_r8	
+        atab1 	= 12.37208932_r8
         btab1 	= -0.16125516114_r8
         ctab1 	= -30.490657554_r8
         dtab1 	= -2.1133114241_r8
-        atab2 	= 13.455394705_r8	
+        atab2 	= 13.455394705_r8
         btab2 	= -0.1921312255_r8
         ctab2 	= -34.285174607_r8
         dtab2 	= -1.7620073078_r8
@@ -1078,7 +1078,7 @@ end subroutine modal_aero_wateruptake_sub
         btab1 	= -0.20786404244_r8
         ctab1 	= -4.807306373_r8
         dtab1 	= -5.1727540348_r8
-        atab2 	= 12.891938068_r8	
+        atab2 	= 12.891938068_r8
         btab2 	= -0.23233847708_r8
         ctab2 	= -6.4261237757_r8
         dtab2 	= -4.9005471319_r8
@@ -1106,7 +1106,7 @@ end subroutine modal_aero_wateruptake_sub
 
       wtpct = (100._r8*contt*98._r8)/conwtp
       wtpct = min(max(wtpct,25._r8),100._r8) ! restrict between 1 and 100 %
-      
+
       return
       end subroutine calc_h2so4_wtpct
 
@@ -1114,5 +1114,3 @@ end subroutine modal_aero_wateruptake_sub
 !----------------------------------------------------------------------
 
    end module modal_aero_wateruptake
-
-

--- a/src/physics/cam/aer_rad_props.F90
+++ b/src/physics/cam/aer_rad_props.F90
@@ -2,7 +2,7 @@ module aer_rad_props
 
 !------------------------------------------------------------------------------------------------
 ! Converts aerosol masses to bulk optical properties for sw and lw radiation
-! computations.  
+! computations.
 !------------------------------------------------------------------------------------------------
 
 use shr_kind_mod,     only: r8 => shr_kind_r8
@@ -89,11 +89,11 @@ subroutine aer_rad_props_init()
    end do
 
    ! Determine default fields
-   if (history_amwg .or. history_dust ) then 
+   if (history_amwg .or. history_dust ) then
       call add_default ('AEROD_v', 1, ' ')
-   endif   
-   
-   if ( history_aero_optics ) then 
+   endif
+
+   if ( history_aero_optics ) then
       call add_default ('AEROD_v', 1, ' ')
       do i = 1, numaerosols
          odv_names(i) = 'ODV_'//trim(aernames(i))
@@ -118,7 +118,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
    ! Arguments
    integer,             intent(in) :: list_idx      ! index of the climate or a diagnostic list
    type(physics_state), intent(in), target :: state
-   
+
    type(physics_buffer_desc), pointer :: pbuf(:)
    integer,             intent(in) :: nnite                ! number of night columns
    integer,             intent(in) :: idxnite(:)           ! local column indices of night columns
@@ -170,7 +170,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
    real(r8) :: rhtrunc(pcols,pver)
    real(r8) :: wrh(pcols,pver)
    integer  :: krh(pcols,pver)
- 
+
    integer  :: numaerosols     ! number of bulk aerosols in climate/diagnostic list
    integer  :: nmodes          ! number of aerosol modes in climate/diagnostic list
    integer  :: iaerosol        ! index into bulk aerosol list
@@ -223,14 +223,14 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
       tau_w_g(1:ncol,:,:) = 0._r8
       tau_w_f(1:ncol,:,:) = 0._r8
    end if
-   
+
    call tropopause_find(state, troplev)
 
    ! Contributions from bulk aerosols.
    do iaerosol = 1, numaerosols
 
       ! get bulk aerosol mass mixing ratio
-      call rad_cnst_get_aer_mmr(list_idx, iaerosol, state, pbuf, aermmr)
+      call rad_cnst_get_aer_mmr(list_idx, iaerosol, state%q, pbuf, aermmr)
       aermass(1:ncol,1:top_lev-1) = 0._r8
       aermass(1:ncol,top_lev:pver) = aermmr(1:ncol,top_lev:pver) * mmr_to_mass(1:ncol,top_lev:pver)
 
@@ -310,14 +310,14 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
    ! Purpose: Compute aerosol transmissions needed in absorptivity/
    !    emissivity calculations
 
-   ! lw extinction is the same representation for all 
+   ! lw extinction is the same representation for all
    ! species.  If this changes, this routine will need to do something
    ! similar to the sw with routines like get_hygro_lw_abs
 
    ! Arguments
    integer,             intent(in)  :: list_idx                      ! index of the climate or a diagnostic list
    type(physics_state), intent(in), target :: state
-   
+
    type(physics_buffer_desc), pointer :: pbuf(:)
    real(r8),            intent(out) :: odap_aer(pcols,pver,nlwbands) ! [fraction] absorption optical depth, per layer
 
@@ -336,7 +336,7 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
    real(r8), pointer :: lw_abs(:)
    real(r8), pointer :: lw_hygro_abs(:,:)
    real(r8), pointer :: geometric_radius(:,:)
- 
+
    ! volcanic lookup table
    real(r8), pointer :: r_lw_abs(:,:)  ! radius dependent mass-specific absorption coefficient
    real(r8), pointer :: r_mu(:)        ! log(geometric_mean_radius) domain samples of r_lw_abs(:,:)
@@ -398,7 +398,7 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
    do iaerosol = 1, numaerosols
 
       ! get aerosol mass mixing ratio
-      call rad_cnst_get_aer_mmr(list_idx, iaerosol, state, pbuf,  aermmr)
+      call rad_cnst_get_aer_mmr(list_idx, iaerosol, state%q, pbuf,  aermmr)
       aermass(1:ncol,1:top_lev-1) = 0._r8
       aermass(1:ncol,top_lev:pver) = aermmr(1:ncol,top_lev:pver) * mmr_to_mass(1:ncol,top_lev:pver)
 
@@ -422,13 +422,13 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
           ! get optical properties for hygroscopic aerosols
          call rad_cnst_get_aer_props(list_idx, iaerosol, lw_ext=lw_abs)
          do bnd_idx = 1, nlwbands
-            do k = 1, pver          
+            do k = 1, pver
                do i = 1, ncol
                   odap_aer(i,k,bnd_idx) = odap_aer(i,k,bnd_idx) + lw_abs(bnd_idx)*aermass(i,k)
                end do
             end do
          end do
-         
+
       case('volcanic_radius','volcanic_radius1','volcanic_radius2','volcanic_radius3')
          pbuf_fld = 'VOLC_RAD_GEOM '
          if (len_trim(opticstype)>15) then
@@ -440,7 +440,7 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
          ! get microphysical properties for volcanic aerosols
          idx = pbuf_get_index(pbuf_fld)
          call pbuf_get_field(pbuf, idx, geometric_radius )
-         
+
          ! interpolate in radius
          ! caution: clip the table with no warning when outside bounds
          nmu = size(r_mu)
@@ -509,7 +509,7 @@ subroutine get_hygro_rad_props(ncol, krh, wrh, mass, ext, ssa, asm, &
                       - wrh(icol,ilev)  * ssa(krh(icol,ilev),  iswband)
             asm1 = (1 + wrh(icol,ilev)) * asm(krh(icol,ilev)+1,iswband) &
                       - wrh(icol,ilev)  * asm(krh(icol,ilev),  iswband)
-  
+
             tau    (icol, ilev, iswband) = mass(icol, ilev) * ext1
             tau_w  (icol, ilev, iswband) = mass(icol, ilev) * ext1 * ssa1
             tau_w_g(icol, ilev, iswband) = mass(icol, ilev) * ext1 * ssa1 * asm1
@@ -518,10 +518,10 @@ subroutine get_hygro_rad_props(ncol, krh, wrh, mass, ext, ssa, asm, &
       enddo
    enddo
 
-end subroutine get_hygro_rad_props 
+end subroutine get_hygro_rad_props
 
 !==============================================================================
-    
+
 subroutine get_nonhygro_rad_props(ncol, mass, ext, ssa, asm, &
                                   tau, tau_w, tau_w_g, tau_w_f)
 
@@ -535,13 +535,13 @@ subroutine get_nonhygro_rad_props(ncol, mass, ext, ssa, asm, &
    real(r8), intent(out) :: tau    (pcols, pver, nswbands)
    real(r8), intent(out) :: tau_w  (pcols, pver, nswbands)
    real(r8), intent(out) :: tau_w_g(pcols, pver, nswbands)
-   real(r8), intent(out) :: tau_w_f(pcols, pver, nswbands) 
+   real(r8), intent(out) :: tau_w_f(pcols, pver, nswbands)
 
    ! Local variables
    integer  :: iswband
    real(r8) :: ext1, ssa1, asm1
    !-----------------------------------------------------------------------------
-   
+
    do iswband = 1, nswbands
       ext1 = ext(iswband)
       ssa1 = ssa(iswband)
@@ -555,11 +555,11 @@ subroutine get_nonhygro_rad_props(ncol, mass, ext, ssa, asm, &
 end subroutine get_nonhygro_rad_props
 
 !==============================================================================
-    
+
 subroutine get_volcanic_radius_rad_props(ncol, mass, pbuf_radius_name, pbuf,  r_ext, r_scat, r_ascat, r_mu, &
                                   tau, tau_w, tau_w_g, tau_w_f)
 
-   
+
    use physics_buffer, only : pbuf_get_field, pbuf_get_index
 
    ! Arguments
@@ -575,7 +575,7 @@ subroutine get_volcanic_radius_rad_props(ncol, mass, pbuf_radius_name, pbuf,  r_
    real(r8), intent(out) :: tau    (pcols, pver, nswbands)
    real(r8), intent(out) :: tau_w  (pcols, pver, nswbands)
    real(r8), intent(out) :: tau_w_g(pcols, pver, nswbands)
-   real(r8), intent(out) :: tau_w_f(pcols, pver, nswbands) 
+   real(r8), intent(out) :: tau_w_f(pcols, pver, nswbands)
 
    ! Local variables
    integer  :: iswband
@@ -586,7 +586,7 @@ subroutine get_volcanic_radius_rad_props(ncol, mass, pbuf_radius_name, pbuf,  r_
    real(r8) :: mu(pcols,pver)                  ! log(geometric mean radius of volcanic aerosol)
    integer  :: kmu, nmu
    real(r8) :: wmu, mutrunc, r_mu_max, r_mu_min
- 
+
    ! interpolated values from table
    real(r8) :: ext(nswbands)
    real(r8) :: scat(nswbands)
@@ -595,10 +595,10 @@ subroutine get_volcanic_radius_rad_props(ncol, mass, pbuf_radius_name, pbuf,  r_
    integer :: i, k ! column level iterator
    !-----------------------------------------------------------------------------
 
-   tau    =0._r8                 
-   tau_w  =0._r8                 
-   tau_w_g=0._r8                 
-   tau_w_f=0._r8                  
+   tau    =0._r8
+   tau_w  =0._r8
+   tau_w_g=0._r8
+   tau_w_f=0._r8
 
    ! get microphysical properties for volcanic aerosols
    idx = pbuf_get_index(pbuf_radius_name)
@@ -634,10 +634,10 @@ subroutine get_volcanic_radius_rad_props(ncol, mass, pbuf_radius_name, pbuf,  r_
             else
                g=0._r8
             endif
-            tau    (i,k,iswband) = mass(i,k) * ext(iswband)  
-            tau_w  (i,k,iswband) = mass(i,k) * scat(iswband)  
-            tau_w_g(i,k,iswband) = mass(i,k) * ascat(iswband)  
-            tau_w_f(i,k,iswband) = mass(i,k) * g * ascat(iswband)  
+            tau    (i,k,iswband) = mass(i,k) * ext(iswband)
+            tau_w  (i,k,iswband) = mass(i,k) * scat(iswband)
+            tau_w_g(i,k,iswband) = mass(i,k) * ascat(iswband)
+            tau_w_f(i,k,iswband) = mass(i,k) * g * ascat(iswband)
          end do
       enddo
    enddo
@@ -645,7 +645,7 @@ subroutine get_volcanic_radius_rad_props(ncol, mass, pbuf_radius_name, pbuf,  r_
 end subroutine get_volcanic_radius_rad_props
 
 !==============================================================================
-    
+
 subroutine get_volcanic_rad_props(ncol, mass, ext, scat, ascat, &
                                   tau, tau_w, tau_w_g, tau_w_f)
 
@@ -659,23 +659,23 @@ subroutine get_volcanic_rad_props(ncol, mass, ext, scat, ascat, &
    real(r8), intent(out) :: tau    (pcols, pver, nswbands)
    real(r8), intent(out) :: tau_w  (pcols, pver, nswbands)
    real(r8), intent(out) :: tau_w_g(pcols, pver, nswbands)
-   real(r8), intent(out) :: tau_w_f(pcols, pver, nswbands) 
+   real(r8), intent(out) :: tau_w_f(pcols, pver, nswbands)
 
    ! Local variables
    integer  :: iswband
    real(r8) :: g
    !-----------------------------------------------------------------------------
-   
+
    do iswband = 1, nswbands
       if (scat(iswband).gt.0._r8) then
          g = ascat(iswband)/scat(iswband)
       else
          g=0._r8
       endif
-      tau    (1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * ext(iswband) 
-      tau_w  (1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * scat(iswband) 
-      tau_w_g(1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * ascat(iswband) 
-      tau_w_f(1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * g * ascat(iswband) 
+      tau    (1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * ext(iswband)
+      tau_w  (1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * scat(iswband)
+      tau_w_g(1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * ascat(iswband)
+      tau_w_f(1:ncol,1:pver,iswband) = mass(1:ncol,1:pver) * g * ascat(iswband)
    enddo
 
 end subroutine get_volcanic_rad_props
@@ -695,7 +695,7 @@ subroutine aer_vis_diag_out(lchnk, ncol, nnite, idxnite, iaer, tau, diag_idx, tr
    integer,          intent(in) :: diag_idx       ! identifies whether the aerosol optics
                                                   ! is for the climate calc or a diagnostic calc
    integer,          intent(in) :: troplev(:)     ! tropopause level
- 
+
    ! Local variables
    integer  :: i
    real(r8) :: tmp(pcols), tmp2(pcols)
@@ -718,7 +718,7 @@ subroutine aer_vis_diag_out(lchnk, ncol, nnite, idxnite, iaer, tau, diag_idx, tr
       do i = 1, ncol
         tmp2(i) = sum(tau(i,:troplev(i)))
       end do
-      call outfld('AODvstrt', tmp2, pcols, lchnk)      
+      call outfld('AODvstrt', tmp2, pcols, lchnk)
    end if
 
 end subroutine aer_vis_diag_out

--- a/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -239,7 +239,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
    call addfld('bc_c1_num',     (/ 'lev' /), 'A', '#/cm3', 'cloud borne bc number')
    call addfld('dst_c1_num',    (/ 'lev' /), 'A', '#/cm3', 'cloud borne dst1 number')
    call addfld('dst_c3_num',    (/ 'lev' /), 'A', '#/cm3', 'cloud borne dst3 number')
-    
+
    call addfld('fn_bc_c1_num',  (/ 'lev' /), 'A', '#/cm3', 'cloud borne bc number derived from fn')
    call addfld('fn_dst_c1_num', (/ 'lev' /), 'A', '#/cm3', 'cloud borne dst1 number derived from fn')
    call addfld('fn_dst_c3_num', (/ 'lev' /), 'A', '#/cm3', 'cloud borne dst3 number derived from fn')
@@ -306,7 +306,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
       call add_default('bc_c1_num', 1, ' ')
       call add_default('dst_c1_num', 1, ' ')
       call add_default('dst_c3_num', 1, ' ')
-    
+
       call add_default('fn_bc_c1_num', 1, ' ')
       call add_default('fn_dst_c1_num', 1, ' ')
       call add_default('fn_dst_c3_num', 1, ' ')
@@ -328,7 +328,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
       call add_default('BCFREZDEP', 1, ' ')
 
       call add_default('NIMIX_IMM', 1, ' ')
-      call add_default('NIMIX_CNT', 1, ' ')  
+      call add_default('NIMIX_CNT', 1, ' ')
       call add_default('NIMIX_DEP', 1, ' ')
 
       call add_default('DSTNIDEP', 1, ' ')
@@ -391,7 +391,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
 
    call rad_cnst_get_mode_props(0, mode_accum_idx, sigmag=sigma_logr_aer)
    alnsg_mode_accum = log(sigma_logr_aer)
-    
+
    if (nmodes == MAM3_nmodes) then
       call rad_cnst_get_mode_props(0, mode_coarse_idx, sigmag=sigma_logr_aer)
       alnsg_mode_coarse = log(sigma_logr_aer)
@@ -415,7 +415,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
    end if
 
    ! Set list indices for all constituents (mass and number) used in this module.
-   ! The list is specific to the aerosol model used.  Note that the order of the 
+   ! The list is specific to the aerosol model used.  Note that the order of the
    ! constituents in these lists is arbitrary.
 
    if (nmodes == MAM3_nmodes) then
@@ -466,7 +466,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
       num_pcarbon  = 14
    end if
 
-   ! Allocate arrays to hold specie and mode indices for all constitutents (mass and number) 
+   ! Allocate arrays to hold specie and mode indices for all constitutents (mass and number)
    ! needed in this module.
    allocate(mode_idx(ncnst), spec_idx(ncnst), stat=istat)
    call alloc_err(istat, routine, 'mode_idx, spec_idx', ncnst)
@@ -545,7 +545,7 @@ subroutine hetfrz_classnuc_cam_init(mincld_in)
       spec_idx(pom_pcarbon) = rad_cnst_get_spec_idx(0, mode_pcarbon_idx, 'p-organic')
       mode_idx(pom_pcarbon) = mode_pcarbon_idx
    end if
- 
+
    ! Check that all required specie types were found
    if (any(spec_idx == -1)) then
       write(iulog,*) routine//': ERROR required species type not found - indicies:', spec_idx
@@ -579,7 +579,7 @@ subroutine hetfrz_classnuc_cam_calc( &
    real(r8),                    intent(in)    :: deltatin       ! time step (s)
    real(r8),                    intent(in)    :: factnum(:,:,:) ! activation fraction for aerosol number
    type(physics_buffer_desc),   pointer       :: pbuf(:)
- 
+
    ! local workspace
 
    ! outputs shared with the microphysics via the pbuf
@@ -592,7 +592,7 @@ subroutine hetfrz_classnuc_cam_calc( &
 
    real(r8) :: rho(pcols,pver)          ! air density (kg m-3)
 
-   real(r8), pointer :: ast(:,:)        
+   real(r8), pointer :: ast(:,:)
 
    real(r8) :: lcldm(pcols,pver)
 
@@ -611,7 +611,7 @@ subroutine hetfrz_classnuc_cam_calc( &
 
    real(r8) :: fn_cloudborne_aer_num(pcols,pver,3)
 
-   real(r8) :: esi(pcols), esl(pcols) 
+   real(r8) :: esi(pcols), esl(pcols)
    real(r8) :: con1, r3lx, supersatice
 
    real(r8) :: qcic
@@ -668,9 +668,9 @@ subroutine hetfrz_classnuc_cam_calc( &
 
       ! Check whether constituent is a mass or number mixing ratio
       if (spec_idx(i) == 0) then
-         call rad_cnst_get_mode_num(0, mode_idx(i), 'a', state, pbuf, ptr2d)
+         call rad_cnst_get_mode_num(0, mode_idx(i), 'a', state%q, pbuf, ptr2d)
       else
-         call rad_cnst_get_aer_mmr(0, mode_idx(i), spec_idx(i), 'a', state, pbuf, ptr2d)
+         call rad_cnst_get_aer_mmr(0, mode_idx(i), spec_idx(i), 'a', state%q, pbuf, ptr2d)
       end if
       aer(:ncol,:,i,lchnk) = ptr2d(:ncol,:) * rho(:ncol,:)
    end do
@@ -702,8 +702,8 @@ subroutine hetfrz_classnuc_cam_calc( &
             fn_cloudborne_aer_num(i,k,2) = total_aer_num(i,k,2)*factnum(i,k,mode_accum_idx)  ! dst_a1
             fn_cloudborne_aer_num(i,k,3) = total_aer_num(i,k,3)*factnum(i,k,mode_coarse_idx) ! dst_a3
          else if (nmodes == MAM7_nmodes) then
-            fn_cloudborne_aer_num(i,k,2) = total_aer_num(i,k,2)*factnum(i,k,mode_finedust_idx) 
-            fn_cloudborne_aer_num(i,k,3) = total_aer_num(i,k,3)*factnum(i,k,mode_coardust_idx) 
+            fn_cloudborne_aer_num(i,k,2) = total_aer_num(i,k,2)*factnum(i,k,mode_finedust_idx)
+            fn_cloudborne_aer_num(i,k,3) = total_aer_num(i,k,3)*factnum(i,k,mode_coardust_idx)
          end if
       end do
    end do
@@ -731,7 +731,7 @@ subroutine hetfrz_classnuc_cam_calc( &
    call outfld('fn_bc_c1_num',  fn_cloudborne_aer_num(:,:,1),      pcols, lchnk)
    call outfld('fn_dst_c1_num', fn_cloudborne_aer_num(:,:,2),      pcols, lchnk)
    call outfld('fn_dst_c3_num', fn_cloudborne_aer_num(:,:,3),      pcols, lchnk)
-        
+
    call outfld('na500',         na500,     pcols, lchnk)
    call outfld('totna500',      tot_na500, pcols, lchnk)
 
@@ -739,7 +739,7 @@ subroutine hetfrz_classnuc_cam_calc( &
    call pbuf_get_field(pbuf, frzimm_idx, frzimm)
    call pbuf_get_field(pbuf, frzcnt_idx, frzcnt)
    call pbuf_get_field(pbuf, frzdep_idx, frzdep)
-    
+
    frzimm(:ncol,:) = 0._r8
    frzcnt(:ncol,:) = 0._r8
    frzdep(:ncol,:) = 0._r8
@@ -795,8 +795,8 @@ subroutine hetfrz_classnuc_cam_calc( &
                 fn(2) = factnum(i,k,mode_accum_idx)  ! dust_a1 accumulation mode
                 fn(3) = factnum(i,k,mode_coarse_idx) ! dust_a3 coarse mode
             else if (nmodes == MAM7_nmodes) then
-                fn(2) = factnum(i,k,mode_finedust_idx)  
-                fn(3) = factnum(i,k,mode_coardust_idx)   
+                fn(2) = factnum(i,k,mode_finedust_idx)
+                fn(3) = factnum(i,k,mode_coardust_idx)
             end if
 
             call hetfrz_classnuc_calc( &
@@ -828,7 +828,7 @@ subroutine hetfrz_classnuc_cam_calc( &
          nnudep_bc(i,k) = frzbcdep(i,k)*1.0e6_r8*ast(i,k)
 
          nnuccc_dst(i,k) = frzduimm(i,k)*1.0e6_r8*ast(i,k)
-         nnucct_dst(i,k) = frzducnt(i,k)*1.0e6_r8*ast(i,k)     
+         nnucct_dst(i,k) = frzducnt(i,k)*1.0e6_r8*ast(i,k)
          nnudep_dst(i,k) = frzdudep(i,k)*1.0e6_r8*ast(i,k)
 
          niimm_bc(i,k) = frzbcimm(i,k)*1.0e6_r8*deltatin
@@ -859,7 +859,7 @@ subroutine hetfrz_classnuc_cam_calc( &
    call outfld('BCFREZDEP', nnudep_bc, pcols, lchnk)
 
    call outfld('NIMIX_IMM', niimm_bc+niimm_dst, pcols, lchnk)
-   call outfld('NIMIX_CNT', nicnt_bc+nicnt_dst, pcols, lchnk)   
+   call outfld('NIMIX_CNT', nicnt_bc+nicnt_dst, pcols, lchnk)
    call outfld('NIMIX_DEP', nidep_bc+nidep_dst, pcols, lchnk)
 
    call outfld('DSTNICNT', nicnt_dst, pcols, lchnk)
@@ -900,9 +900,9 @@ subroutine hetfrz_classnuc_cam_save_cbaero(state, pbuf)
 
       ! Check whether constituent is a mass or number mixing ratio
       if (spec_idx(i) == 0) then
-         call rad_cnst_get_mode_num(0, mode_idx(i), 'c', state, pbuf, ptr2d)
+         call rad_cnst_get_mode_num(0, mode_idx(i), 'c', state%q, pbuf, ptr2d)
       else
-         call rad_cnst_get_aer_mmr(0, mode_idx(i), spec_idx(i), 'c', state, pbuf, ptr2d)
+         call rad_cnst_get_aer_mmr(0, mode_idx(i), spec_idx(i), 'c', state%q, pbuf, ptr2d)
       end if
       aer_cb(:,:,i,lchnk) = ptr2d
    end do
@@ -919,7 +919,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
                        total_cloudborne_aer_num,          &
                        hetraer, awcam, awfacm, dstcoat,   &
                        na500, tot_na500)
-    
+
    !*****************************************************************************
    ! Purpose: Calculate BC and Dust number, including total number(interstitial+
    !          cloud borne), one monolayer coated number, and uncoated number
@@ -940,7 +940,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
    real(r8), intent(out) :: total_aer_num(3)            ! #/cm^3
    real(r8), intent(out) :: total_interstial_aer_num(3) ! #/cm^3
    real(r8), intent(out) :: total_cloudborne_aer_num(3) ! #/cm^3
-   real(r8), intent(out) :: coated_aer_num(3)           ! #/cm^3 
+   real(r8), intent(out) :: coated_aer_num(3)           ! #/cm^3
    real(r8), intent(out) :: uncoated_aer_num(3)         ! #/cm^3
    real(r8), intent(out) :: hetraer(3)                  ! BC and Dust mass mean radius [m]
    real(r8), intent(out) :: awcam(3)                    ! modal added mass [mug m-3]
@@ -960,10 +960,10 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
    real(r8), parameter :: soa_equivso4_factor = spechygro_soa/spechygro_so4
    real(r8), parameter :: pom_equivso4_factor = spechygro_pom/spechygro_so4
    real(r8) :: vol_shell(3)
-   real(r8) :: vol_core(3) 
+   real(r8) :: vol_core(3)
    real(r8) :: fac_volsfc_dust_a1, fac_volsfc_dust_a3, fac_volsfc_bc
    real(r8) :: tmp1, tmp2
-   real(r8) :: bc_num                     ! bc number in accumulation mode for MAM3 
+   real(r8) :: bc_num                     ! bc number in accumulation mode for MAM3
                                           ! bc number in accumulation and primary carbon mode for MAM7 and MAM4
    real(r8) :: dst1_num, dst3_num         ! dust number in accumulation and corase mode for MAM3
                                           ! dust number in fine dust and corase dust mode for MAM7 and MAM4
@@ -978,8 +978,8 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
    real(r8) :: dmc_imm, ssmc_imm
    real(r8) :: as_bc, as_pom, as_ss
 
-   real(r8) :: r_bc                         ! model radii of BC modes [m]   
-   real(r8) :: r_dust_a1, r_dust_a3         ! model radii of dust modes [m]   
+   real(r8) :: r_bc                         ! model radii of BC modes [m]
+   real(r8) :: r_dust_a1, r_dust_a3         ! model radii of dust modes [m]
 
    integer :: i
    real(r8) :: dst1_scale
@@ -999,9 +999,9 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
    tot_na500                 = 0._r8
 
    !*****************************************************************************
-   !                calculate intersitial aerosol 
+   !                calculate intersitial aerosol
    !*****************************************************************************
-   
+
    if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes .or. nmodes == MAM5_nmodes) then
 
       if (.not. num_to_mass_in) then
@@ -1034,7 +1034,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       end if
       dmc = aer(ii,kk,dst_coarse)
       ssmc = aer(ii,kk,ncl_coarse)
-      
+
       if (dmc > 0._r8 ) then
          dst3_num = dmc/(ssmc+dmc) * aer(ii,kk,num_coarse)*1.0e-6_r8 ! #/cm^3
       else
@@ -1047,13 +1047,13 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
    else if (nmodes == MAM7_nmodes) then
       bc_num = (aer(ii,kk,bc_accum)+aer(ii,kk,bc_pcarbon)) * bc_num_to_mass*1.0e-6_r8 ! #/cm^3
       dst1_num = aer(ii,kk,num_finedust)*1.0e-6_r8  ! #/cm^3
-      dst3_num = aer(ii,kk,num_coardust)*1.0e-6_r8 ! #/cm^3    
+      dst3_num = aer(ii,kk,num_coardust)*1.0e-6_r8 ! #/cm^3
    end if
 
    !*****************************************************************************
-   !                calculate cloud borne aerosol 
-   !*****************************************************************************    
-   
+   !                calculate cloud borne aerosol
+   !*****************************************************************************
+
    if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes .or. nmodes == MAM5_nmodes) then
 
       as_so4 = aer_cb(ii,kk,so4_accum)
@@ -1076,7 +1076,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       else
          bc_num_imm = 0.0_r8
       end if
-       
+
       dmc_imm = aer_cb(ii,kk,dst_coarse)
       ssmc_imm = aer_cb(ii,kk,ncl_coarse)
 
@@ -1105,16 +1105,16 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
    total_interstial_aer_num(1) = bc_num
    total_interstial_aer_num(2) = dst1_num
-   total_interstial_aer_num(3) = dst3_num 
+   total_interstial_aer_num(3) = dst3_num
 
-   total_cloudborne_aer_num(1) = bc_num_imm 
-   total_cloudborne_aer_num(2) = dst1_num_imm 
+   total_cloudborne_aer_num(1) = bc_num_imm
+   total_cloudborne_aer_num(2) = dst1_num_imm
    total_cloudborne_aer_num(3) = dst3_num_imm
-  
-   !*****************************************************************************    
+
+   !*****************************************************************************
    ! calculate mass mean radius
-   !*****************************************************************************    
-   
+   !*****************************************************************************
+
    if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes .or. nmodes == MAM5_nmodes) then
 
       if (nmodes == MAM3_nmodes) then
@@ -1157,7 +1157,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       else
           r_bc = 0.067e-6_r8 ! from emission size
       end if
-      
+
       if (aer(ii,kk,dst_finedust)*1.0e-3_r8 > 1.0e-30_r8 .and. dst1_num > 1.0e-3_r8) then
          r_dust_a1 = ( 3._r8/(4*pi*specdens_dust)*aer(ii,kk,dst_finedust)/(dst1_num*1.0e6_r8) )**(1._r8/3._r8)
       else
@@ -1169,16 +1169,16 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       else
          r_dust_a3 = 1.576e-6_r8
       end if
-   end if    
+   end if
 
    hetraer(1) = r_bc
    hetraer(2) = r_dust_a1
    hetraer(3) = r_dust_a3
 
    !*****************************************************************************
-   !                calculate coated fraction 
+   !                calculate coated fraction
    !*****************************************************************************
-   
+
    if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes .or. nmodes == MAM5_nmodes) then
 
       fac_volsfc_bc      = exp(2.5_r8*alnsg_mode_accum**2)
@@ -1191,16 +1191,16 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
       vol_core(2) = aer(ii,kk,dst_accum)/(specdens_dust*rhoair)
 
-      !   ratio1 = vol_shell/vol_core = 
+      !   ratio1 = vol_shell/vol_core =
       !      actual hygroscopic-shell-volume/dust-core-volume
       !   ratio2 = 6.0_r8*dr_so4_monolayers_pcage/(dgncur_a*fac_volsfc_dust)
-      !      = (shell-volume corresponding to n_so4_monolayers_pcage)/core-volume 
+      !      = (shell-volume corresponding to n_so4_monolayers_pcage)/core-volume
       !      The 6.0/(dgncur_a*fac_volsfc_dust) = (mode-surface-area/mode-volume)
       !   Note that vol_shell includes both so4, pom, AND soa as "equivalent so4",
       !      The soa_equivso4_factor accounts for the lower hygroscopicity of soa.
       !
       !   Define xferfrac_pcage = min( 1.0, ratio1/ratio2)
-      !   But ratio1/ratio2 == tmp1/tmp2, and coding below avoids possible overflow 
+      !   But ratio1/ratio2 == tmp1/tmp2, and coding below avoids possible overflow
 
       ! bc
       if (nmodes == MAM3_nmodes) then
@@ -1255,10 +1255,10 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
       vol_shell(3) = aer(ii,kk,so4_coardust)/(specdens_so4*rhoair)
       vol_core(3)  = aer(ii,kk,dst_coardust)/(specdens_dust*rhoair)
-      tmp1 = vol_shell(3)*(r_dust_a3*2._r8)*fac_volsfc_dust_a3 
+      tmp1 = vol_shell(3)*(r_dust_a3*2._r8)*fac_volsfc_dust_a3
       tmp2 = max(6.0_r8*dr_so4_monolayers_dust*vol_core(3), 0.0_r8)
       dstcoat(3) = tmp1/tmp2
-    
+
    end if
 
    if (dstcoat(1) > 1._r8)    dstcoat(1) = 1._r8
@@ -1267,19 +1267,19 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
    if (dstcoat(2) < 0.001_r8) dstcoat(2) = 0.001_r8
    if (dstcoat(3) > 1._r8)    dstcoat(3) = 1._r8
    if (dstcoat(3) < 0.001_r8) dstcoat(3) = 0.001_r8
-   
+
    do i = 1, 3
       total_aer_num(i)    = total_interstial_aer_num(i) + total_cloudborne_aer_num(i)
       coated_aer_num(i)   = total_interstial_aer_num(i)*dstcoat(i)
       uncoated_aer_num(i) = total_interstial_aer_num(i)*(1._r8-dstcoat(i))
    end do
-    
+
    if (nmodes == MAM4_nmodes .or. nmodes == MAM7_nmodes .or. nmodes == MAM5_nmodes) then
       coated_aer_num(1)   = (aer(ii,kk,bc_pcarbon)*bc_num_to_mass*1.0e-6_r8)*dstcoat(1)+ &
                             (aer(ii,kk,bc_accum)*bc_num_to_mass*1.0e-6_r8)
       uncoated_aer_num(1) = (aer(ii,kk,bc_pcarbon)*bc_num_to_mass*1.0e-6_r8)*(1._r8-dstcoat(1))
    end if
-    
+
    if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes .or. nmodes == MAM5_nmodes) then
       dst1_scale = 0.488_r8    ! scaled for D>0.5-1 um from 0.1-1 um
    else if (nmodes == MAM7_nmodes) then
@@ -1293,12 +1293,12 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
       + total_interstial_aer_num(2)*dst1_scale + total_interstial_aer_num(3)
 
    !*****************************************************************************
-   !                prepare some variables for water activity 
+   !                prepare some variables for water activity
    !*****************************************************************************
-   
+
    if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes .or. nmodes == MAM5_nmodes) then
-      ! accumulation mode for dust_a1 
-      if (aer(ii,kk,num_accum) > 0._r8) then 
+      ! accumulation mode for dust_a1
+      if (aer(ii,kk,num_accum) > 0._r8) then
          awcam(2) = (dst1_num*1.0e6_r8)/aer(ii,kk,num_accum)* &
             ( aer(ii,kk,so4_accum) + aer(ii,kk,soa_accum) + &
             aer(ii,kk,pom_accum) + aer(ii,kk,bc_accum) )*1.0e9_r8 ! [mug m-3]
@@ -1306,7 +1306,7 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
          awcam(2) = 0._r8
       end if
 
-      if (awcam(2) > 0._r8) then   
+      if (awcam(2) > 0._r8) then
          awfacm(2) = ( aer(ii,kk,bc_accum) + aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) )/ &
             ( aer(ii,kk,soa_accum) + aer(ii,kk,pom_accum) + aer(ii,kk,so4_accum) + aer(ii,kk,bc_accum) )
       else
@@ -1356,13 +1356,13 @@ subroutine get_aer_num(ii, kk, ncnst, aer, aer_cb, rhoair,&
 
       if (aer(ii,kk,num_coardust) > 0._r8) then
          awcam(3) = (dst3_num*1.0e6_r8)/aer(ii,kk,num_coardust)* aer(ii,kk,so4_coardust)*1.0e9_r8
-      else 
+      else
          awcam(3) = 0._r8
       end if
       awfacm(3) = 0._r8
 
    end if
-  
+
 end subroutine get_aer_num
 
 !====================================================================================================

--- a/src/physics/cam/microp_aero.F90
+++ b/src/physics/cam/microp_aero.F90
@@ -529,13 +529,13 @@ subroutine microp_aero_run ( &
 
    if (clim_modal_aero) then
       ! mode number mixing ratios
-      call rad_cnst_get_mode_num(0, mode_coarse_dst_idx, 'a', state1, pbuf, num_coarse)
+      call rad_cnst_get_mode_num(0, mode_coarse_dst_idx, 'a', state1%q, pbuf, num_coarse)
 
       ! mode specie mass m.r.
-      call rad_cnst_get_aer_mmr(0, mode_coarse_dst_idx, coarse_dust_idx, 'a', state1, pbuf, coarse_dust)
-      call rad_cnst_get_aer_mmr(0, mode_coarse_slt_idx, coarse_nacl_idx, 'a', state1, pbuf, coarse_nacl)
+      call rad_cnst_get_aer_mmr(0, mode_coarse_dst_idx, coarse_dust_idx, 'a', state1%q, pbuf, coarse_dust)
+      call rad_cnst_get_aer_mmr(0, mode_coarse_slt_idx, coarse_nacl_idx, 'a', state1%q, pbuf, coarse_nacl)
       if (mode_coarse_idx>0) then
-         call rad_cnst_get_aer_mmr(0, mode_coarse_idx, coarse_so4_idx, 'a', state1, pbuf, coarse_so4)
+         call rad_cnst_get_aer_mmr(0, mode_coarse_idx, coarse_so4_idx, 'a', state1%q, pbuf, coarse_so4)
       endif
 
    else
@@ -545,7 +545,7 @@ subroutine microp_aero_run ( &
          maerosol(pcols,pver,naer_all))
 
       do m = 1, naer_all
-         call rad_cnst_get_aer_mmr(0, m, state1, pbuf, aer_mmr)
+         call rad_cnst_get_aer_mmr(0, m, state1%q, pbuf, aer_mmr)
          maerosol(:ncol,:,m) = aer_mmr(:ncol,:)*rho(:ncol,:)
 
          if (m .eq. idxsul) then
@@ -652,7 +652,7 @@ subroutine microp_aero_run ( &
       call outfld('LCLOUD', lcldn, pcols, lchnk)
 
       ! create the aerosol state object
-      aero_state_obj => modal_aerosol_state( state1, pbuf, aero_props_obj )
+      aero_state_obj => modal_aerosol_state( pbuf, aero_props_obj )
 
       allocate(factnum(pcols,pver,aero_props_obj%nbins()))
 

--- a/src/physics/cam/modal_aer_opt.F90
+++ b/src/physics/cam/modal_aer_opt.F90
@@ -115,7 +115,7 @@ subroutine modal_aer_opt_init()
    integer  :: i, m
    real(r8) :: rmmin, rmmax       ! min, max aerosol surface mode radius treated (m)
    character(len=256) :: locfile
-   
+
    logical           :: history_amwg            ! output the variables used by the AMWG diag package
    logical           :: history_aero_optics     ! output aerosol optics diagnostics
    logical           :: history_dust            ! output dust diagnostics
@@ -337,21 +337,21 @@ subroutine modal_aer_opt_init()
    call addfld ('SSAVISdn',        horiz_only, 'A','  ',    'Aerosol single-scatter albedo, day night',                  &
         flag_xyfill=.true.)
 
- 
-   if (history_amwg) then 
+
+   if (history_amwg) then
       call add_default ('AODDUST1'     , 1, ' ')
       call add_default ('AODDUST3'     , 1, ' ')
       call add_default ('AODDUST'      , 1, ' ')
       call add_default ('AODVIS'       , 1, ' ')
    end if
 
-   if (history_dust) then 
+   if (history_dust) then
       call add_default ('AODDUST1'     , 1, ' ')
       call add_default ('AODDUST2'     , 1, ' ')
       call add_default ('AODDUST3'     , 1, ' ')
    end if
 
-   if (history_aero_optics) then 
+   if (history_aero_optics) then
       call add_default ('AODDUST1'     , 1, ' ')
       call add_default ('AODDUST3'     , 1, ' ')
       call add_default ('ABSORB'       , 1, ' ')
@@ -382,7 +382,7 @@ subroutine modal_aer_opt_init()
       call add_default ('EXTINCT'      , 1, ' ')
       call add_default ('AODxASYM'     , 1, ' ')
       call add_default ('EXTxASYM'     , 1, ' ')
-     
+
       call add_default ('AODdnDUST1'     , 1, ' ')
       call add_default ('AODdnDUST3'     , 1, ' ')
       call add_default ('ABSORBdn'       , 1, ' ')
@@ -417,7 +417,7 @@ subroutine modal_aer_opt_init()
 
    do ilist = 1, n_diag
       if (call_list(ilist)) then
-         
+
          call addfld ('EXTINCT'//diag(ilist),  (/ 'lev' /), 'A','/m', &
               'Aerosol extinction', flag_xyfill=.true.)
          call addfld ('ABSORB'//diag(ilist),   (/ 'lev' /), 'A','/m', &
@@ -463,12 +463,12 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
                          tauxar, wa, ga, fa)
 
    ! calculates aerosol sw radiative properties
-   
+
    use tropopause, only : tropopause_findChemTrop
 
    integer,             intent(in) :: list_idx       ! index of the climate or a diagnostic list
    type(physics_state), intent(in), target :: state          ! state variables
-   
+
    type(physics_buffer_desc), pointer :: pbuf(:)
    integer,             intent(in) :: nnite          ! number of night columns
    integer,             intent(in) :: idxnite(nnite) ! local column indices of night columns
@@ -494,7 +494,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
    real(r8)             :: specdens            ! species density (kg/m3)
    complex(r8), pointer :: specrefindex(:)     ! species refractive index
    character*32         :: spectype            ! species type
-   real(r8)             :: hygro_aer           ! 
+   real(r8)             :: hygro_aer           !
 
    real(r8), pointer :: dgnumwet(:,:)     ! number mode wet diameter
    real(r8), pointer :: qaerwat(:,:)      ! aerosol water (g/g)
@@ -502,13 +502,13 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
    real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
    real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
    real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
-   real(r8), pointer :: wetdens_m(:,:,:)  ! 
-   real(r8), pointer :: hygro_m(:,:,:)  ! 
-   real(r8), pointer :: dryvol_m(:,:,:)  ! 
-   real(r8), pointer :: dryrad_m(:,:,:)  ! 
-   real(r8), pointer :: drymass_m(:,:,:)  ! 
-   real(r8), pointer :: so4dryvol_m(:,:,:)  ! 
-   real(r8), pointer :: naer_m(:,:,:)  ! 
+   real(r8), pointer :: wetdens_m(:,:,:)  !
+   real(r8), pointer :: hygro_m(:,:,:)  !
+   real(r8), pointer :: dryvol_m(:,:,:)  !
+   real(r8), pointer :: dryrad_m(:,:,:)  !
+   real(r8), pointer :: drymass_m(:,:,:)  !
+   real(r8), pointer :: so4dryvol_m(:,:,:)  !
+   real(r8), pointer :: naer_m(:,:,:)  !
 
    real(r8) :: sigma_logr_aer         ! geometric standard deviation of number distribution
    real(r8) :: radsurf(pcols,pver)    ! aerosol surface mode radius
@@ -633,7 +633,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
    asymvis(1:ncol)       = 0.0_r8
    asymext(1:ncol,:)     = 0.0_r8
 
-   aodabsbc(:ncol)       = 0.0_r8 
+   aodabsbc(:ncol)       = 0.0_r8
    dustaod(:ncol)        = 0.0_r8
    so4aod(:ncol)         = 0.0_r8
    pomaod(:ncol)         = 0.0_r8
@@ -669,7 +669,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
          call endrun('modal_aero_sw: allocation FAILURE: arrays for diagnostic calcs')
       end if
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m, hygro_m, &
-                                    dryvol_m, dryrad_m, drymass_m, so4dryvol_m, naer_m)  
+                                    dryvol_m, dryrad_m, drymass_m, so4dryvol_m, naer_m)
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
                                      qaerwat_m, wetdens_m,  hygro_m, dryvol_m, dryrad_m, &
                                      drymass_m, so4dryvol_m, naer_m)
@@ -728,7 +728,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
 
             ! aerosol species loop
             do l = 1, nspec
-               call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state, pbuf, specmmr)
+               call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state%q, pbuf, specmmr)
                call rad_cnst_get_aer_props(list_idx, m, l, density_aer=specdens, &
                                            refindex_aer_sw=specrefindex, spectype=spectype, &
                                            hygro_aer=hygro_aer)
@@ -941,7 +941,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
 
                      scatseasalt(i) = (scatseasalt(i) + scath2o*hygroseasalt(i)/sumhygro)/sumscat
                      absseasalt(i)  = (absseasalt(i) + absh2o*hygroseasalt(i)/sumhygro)/sumabs
-                     
+
                      aodabsbc(i)    = aodabsbc(i) + absbc(i)*dopaer(i)*(1.0_r8-palb(i))
 
                      aodc           = (absdust(i)*(1.0_r8 - palb(i)) + palb(i)*scatdust(i))*dopaer(i)
@@ -988,7 +988,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
                   write(iulog,*) 'nspec=', nspec
                   ! write(iulog,*) 'cheb=', (cheb(nc,m,i,k),nc=2,ncoef)
                   do l = 1, nspec
-                     call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state, pbuf, specmmr)
+                     call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state%q, pbuf, specmmr)
                      call rad_cnst_get_aer_props(list_idx, m, l, density_aer=specdens, &
                                                  refindex_aer_sw=specrefindex)
                      volf = specmmr(i,k)/specdens
@@ -1031,7 +1031,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
 
          write(outname,'(a,i1)') 'AODdnDUST', m
          call outfld(trim(outname), dustaodmode, pcols, lchnk)
-         
+
          do i = 1, nnite
             burden(idxnite(i))  = fillvalue
             aodmode(idxnite(i)) = fillvalue
@@ -1073,7 +1073,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
    call outfld('AODABSdn'//diag(list_idx),   aodabs,  pcols, lchnk)
    call outfld('AODVISstdn'//diag(list_idx), aodvisst,pcols, lchnk)
    call outfld('EXTxASYMdn'//diag(list_idx), asymext, pcols, lchnk)
-   
+
    do i = 1, nnite
       extinct(idxnite(i),:) = fillvalue
       absorb(idxnite(i),:)  = fillvalue
@@ -1099,7 +1099,7 @@ subroutine modal_aero_sw(list_idx, state, pbuf, nnite, idxnite, &
             ssavis(i) = 0.925_r8
          endif
       end do
-      
+
       call outfld('SSAVISdn',        ssavis,        pcols, lchnk)
       call outfld('AODxASYMdn',      asymvis,       pcols, lchnk)
 
@@ -1192,7 +1192,7 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
 
    integer,             intent(in)  :: list_idx ! index of the climate or a diagnostic list
    type(physics_state), intent(in), target :: state    ! state variables
-   
+
    type(physics_buffer_desc), pointer :: pbuf(:)
 
    real(r8), intent(out) :: tauxar(pcols,pver,nlwbands) ! layer absorption optical depth
@@ -1211,7 +1211,7 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
    real(r8), pointer :: dgnumdry_m(:,:,:) ! number mode dry diameter for all modes
    real(r8), pointer :: dgnumwet_m(:,:,:) ! number mode wet diameter for all modes
    real(r8), pointer :: qaerwat_m(:,:,:)  ! aerosol water (g/g) for all modes
-   real(r8), pointer :: wetdens_m(:,:,:)  ! 
+   real(r8), pointer :: wetdens_m(:,:,:)  !
    real(r8), pointer :: hygro_m(:,:,:)  !
    real(r8), pointer :: dryvol_m(:,:,:)  !
    real(r8), pointer :: dryrad_m(:,:,:)  !
@@ -1283,7 +1283,7 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
          call endrun('modal_aero_lw: allocation FAILURE: arrays for diagnostic calcs')
       end if
       call modal_aero_calcsize_diag(state, pbuf, list_idx, dgnumdry_m, hygro_m, &
-                                    dryvol_m, dryrad_m, drymass_m, so4dryvol_m, naer_m)  
+                                    dryvol_m, dryrad_m, drymass_m, so4dryvol_m, naer_m)
       call modal_aero_wateruptake_dr(state, pbuf, list_idx, dgnumdry_m, dgnumwet_m, &
                                      qaerwat_m, wetdens_m,  hygro_m, dryvol_m, dryrad_m, &
                                      drymass_m, so4dryvol_m, naer_m)
@@ -1333,7 +1333,7 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
 
             ! aerosol species loop
             do l = 1, nspec
-               call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state, pbuf, specmmr)
+               call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state%q, pbuf, specmmr)
                call rad_cnst_get_aer_props(list_idx, m, l, density_aer=specdens, &
                                            refindex_aer_lw=specrefindex)
 
@@ -1399,7 +1399,7 @@ subroutine modal_aero_lw(list_idx, state, pbuf, tauxar)
                   write(iulog,*) 'crefin=', crefin(i)
                   write(iulog,*) 'nspec=', nspec
                   do l = 1,nspec
-                     call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state, pbuf, specmmr)
+                     call rad_cnst_get_aer_mmr(list_idx, m, l, 'a', state%q, pbuf, specmmr)
                      call rad_cnst_get_aer_props(list_idx, m, l, density_aer=specdens, &
                                                  refindex_aer_lw=specrefindex)
                      volf = specmmr(i,k)/specdens
@@ -1558,7 +1558,7 @@ end subroutine modal_size_parameters
         real(r8) table(km,im,jm),xtab(im),ytab(jm),out(pcols,km)
         integer i,ix(pcols),ip1,j,jy(pcols),jp1,k,ic,ip1m(pcols),jp1m(pcols),ixc,jyc
         real(r8) x(pcols),dx,t(pcols),y(pcols),dy,u(pcols),tu(pcols),tuc(pcols),tcu(pcols),tcuc(pcols)
-        
+
         if(ix(1).gt.0) go to 30
         if(im.gt.1)then
             do ic=1,ncol

--- a/src/physics/cam/ndrop.F90
+++ b/src/physics/cam/ndrop.F90
@@ -371,7 +371,7 @@ subroutine dropmixnuc( aero_props, aero_state, &
 
    ! Init pointers to mode number and specie mass mixing ratios in
    ! intersitial and cloud borne phases.
-   call aero_state%get_states( aero_props, raer, qqcw )
+   call aero_state%get_states( aero_props, state%q, raer, qqcw )
 
    called_from_spcam = (present(from_spcam))
 
@@ -552,7 +552,7 @@ subroutine dropmixnuc( aero_props, aero_state, &
             do m = 1, nbin
                call aero_state%loadaer( aero_props, &
                   i, i, k, &
-                  m, cs, phase, na, va, &
+                  m, cs, phase, state%q, na, va, &
                   hy)
                naermod(m)  = na(i)
                vaerosol(m) = va(i)
@@ -640,7 +640,7 @@ subroutine dropmixnuc( aero_props, aero_state, &
                   !   aerosol from layer below
                   call aero_state%loadaer( aero_props, &
                      i, i, kp1,  &
-                     m, cs, phase, na, va,   &
+                     m, cs, phase, state%q, na, va,   &
                      hy)
                   naermod(m)  = na(i)
                   vaerosol(m) = va(i)
@@ -1580,7 +1580,7 @@ subroutine ccncalc(aero_state, aero_props, state, cs, ccn)
 
          call aero_state%loadaer( aero_props, &
             1, ncol, k, &
-            m, cs, phase, naerosol, vaerosol, &
+            m, cs, phase, state%q, naerosol, vaerosol, &
             hygro)
 
          where(naerosol(:ncol)>1.e-3_r8 .and. hygro(:ncol).gt.1.e-10_r8)

--- a/src/physics/cam/nucleate_ice_cam.F90
+++ b/src/physics/cam/nucleate_ice_cam.F90
@@ -219,7 +219,7 @@ subroutine nucleate_ice_cam_init(mincld_in, bulk_scale_in, pbuf2d)
    if (((nucleate_ice_subgrid .eq. -1._r8) .or. (nucleate_ice_subgrid_strat .eq. -1._r8)) .and. (qsatfac_idx .eq. -1)) then
      call endrun(routine//': ERROR qsatfac is required when subgrid = -1 or subgrid_strat = -1')
    end if
-   
+
    if (cam_physpkg_is("cam_dev")) then
       ! Updates for PUMAS v1.21+
       call addfld('NIHFTEN',  (/ 'lev' /), 'A', '1/m3/s', 'Activated Ice Number Concentration tendency due to homogenous freezing')
@@ -534,24 +534,24 @@ subroutine nucleate_ice_cam_calc( &
 
    if (clim_modal_aero) then
       ! mode number mixing ratios
-      call rad_cnst_get_mode_num(0, mode_accum_idx,  'a', state, pbuf, num_accum)
-      call rad_cnst_get_mode_num(0, mode_aitken_idx, 'a', state, pbuf, num_aitken)
-      call rad_cnst_get_mode_num(0, mode_coarse_dst_idx, 'a', state, pbuf, num_coarse)
+      call rad_cnst_get_mode_num(0, mode_accum_idx,  'a', state%q, pbuf, num_accum)
+      call rad_cnst_get_mode_num(0, mode_aitken_idx, 'a', state%q, pbuf, num_aitken)
+      call rad_cnst_get_mode_num(0, mode_coarse_dst_idx, 'a', state%q, pbuf, num_coarse)
       if (mode_strat_coarse_idx > 0) then
-         call rad_cnst_get_mode_num(0, mode_strat_coarse_idx,  'a', state, pbuf, num_strcrs)
+         call rad_cnst_get_mode_num(0, mode_strat_coarse_idx,  'a', state%q, pbuf, num_strcrs)
       endif
 
       ! mode specie mass m.r.
-      call rad_cnst_get_aer_mmr(0, mode_coarse_dst_idx, coarse_dust_idx, 'a', state, pbuf, coarse_dust)
-      call rad_cnst_get_aer_mmr(0, mode_coarse_slt_idx, coarse_nacl_idx, 'a', state, pbuf, coarse_nacl)
+      call rad_cnst_get_aer_mmr(0, mode_coarse_dst_idx, coarse_dust_idx, 'a', state%q, pbuf, coarse_dust)
+      call rad_cnst_get_aer_mmr(0, mode_coarse_slt_idx, coarse_nacl_idx, 'a', state%q, pbuf, coarse_nacl)
       if (mode_coarse_idx>0) then
-         call rad_cnst_get_aer_mmr(0, mode_coarse_idx, coarse_so4_idx, 'a', state, pbuf, coarse_so4)
+         call rad_cnst_get_aer_mmr(0, mode_coarse_idx, coarse_so4_idx, 'a', state%q, pbuf, coarse_so4)
       endif
 
       ! Get the cloudbourne coarse mode fields, so aerosol used for nucleated
       ! can be moved from interstial to cloudbourne.
-      call rad_cnst_get_mode_num(0, mode_coarse_dst_idx, 'c', state, pbuf, cld_num_coarse)
-      call rad_cnst_get_aer_mmr(0, mode_coarse_dst_idx, coarse_dust_idx, 'c', state, pbuf, cld_coarse_dust)
+      call rad_cnst_get_mode_num(0, mode_coarse_dst_idx, 'c', state%q, pbuf, cld_num_coarse)
+      call rad_cnst_get_aer_mmr(0, mode_coarse_dst_idx, coarse_dust_idx, 'c', state%q, pbuf, cld_coarse_dust)
 
       call physics_ptend_init(ptend, state%psetcols, 'nucleatei', lq=lq)
    else
@@ -561,7 +561,7 @@ subroutine nucleate_ice_cam_calc( &
            maerosol(pcols,pver,naer_all))
 
       do m = 1, naer_all
-         call rad_cnst_get_aer_mmr(0, m, state, pbuf, aer_mmr)
+         call rad_cnst_get_aer_mmr(0, m, state%q, pbuf, aer_mmr)
          maerosol(:ncol,:,m) = aer_mmr(:ncol,:)*rho(:ncol,:)
 
          if (m .eq. idxsul) then
@@ -768,7 +768,7 @@ subroutine nucleate_ice_cam_calc( &
                     oso4_num, odst_num, osoot_num, &
                     call_frm_zm_in = .false., add_preexisting_ice_in = .false.)
 
-            else 
+            else
 
                call nucleati( &
                     wsubi(i,k), t(i,k), pmid(i,k), relhum(i,k), icldm(i,k),   &
@@ -844,14 +844,14 @@ subroutine nucleate_ice_cam_calc( &
               !Updates for pumas v1.21+
 
               naai_hom(i,k) = nihf(i,k)/dtime
-              naai(i,k)= naai(i,k)/dtime            
+              naai(i,k)= naai(i,k)/dtime
 
               ! output activated ice (convert from #/kg -> #/m3/s)
               nihf(i,k)     = nihf(i,k) *rho(i,k)/dtime
               niimm(i,k)    = niimm(i,k)*rho(i,k)/dtime
               nidep(i,k)    = nidep(i,k)*rho(i,k)/dtime
               nimey(i,k)    = nimey(i,k)*rho(i,k)/dtime
-               
+
               if (use_preexisting_ice) then
                  INnso4(i,k) =so4_num*1e6_r8/dtime  ! (convert from #/cm3 -> #/m3/s)
                  INnbc(i,k)  =soot_num*1e6_r8/dtime
@@ -883,7 +883,7 @@ subroutine nucleate_ice_cam_calc( &
            else ! Not cam_dev
 
               naai_hom(i,k) = nihf(i,k)
-              
+
               ! output activated ice (convert from #/kg -> #/m3/s)
               nihf(i,k)     = nihf(i,k) *rho(i,k)
               niimm(i,k)    = niimm(i,k)*rho(i,k)

--- a/src/physics/cam/rad_constituents.F90
+++ b/src/physics/cam/rad_constituents.F90
@@ -2,9 +2,9 @@ module rad_constituents
 
 !------------------------------------------------------------------------------------------------
 !
-! Provide constituent distributions and properties to the radiation and 
+! Provide constituent distributions and properties to the radiation and
 ! cloud microphysics routines.
-! 
+!
 ! The logic to control which constituents are used in the climate calculations
 ! and which are used in diagnostic radiation calculations is contained in this module.
 !
@@ -115,7 +115,7 @@ type(modes_t), target :: modes  ! mode definitions
 ! type to provide access to the data parsed from the rad_climate and rad_diag_* strings
 type :: rad_cnst_namelist_t
    integer :: ncnst
-   character(len=  1), pointer :: source(:)  ! 'A' for state (advected), 'N' for pbuf (non-advected), 
+   character(len=  1), pointer :: source(:)  ! 'A' for state (advected), 'N' for pbuf (non-advected),
                                              ! 'M' for mode, 'Z' for zero
    character(len= 64), pointer :: camname(:) ! name registered in pbuf or constituents
    character(len=cs1), pointer :: radname(:) ! radname is the name as identfied in radiation,
@@ -127,7 +127,7 @@ end type rad_cnst_namelist_t
 type(rad_cnst_namelist_t) :: namelist(0:N_DIAG) ! gas, bulk aerosol, and modal components used in
                                                 ! climate/diagnostic calculations
 
-logical :: active_calls(0:N_DIAG)     ! active_calls(i) is true if the i-th call to radiation is 
+logical :: active_calls(0:N_DIAG)     ! active_calls(i) is true if the i-th call to radiation is
                                       ! specified.  Note that the 0th call is for the climate
                                       ! calculation which is always made.
 
@@ -184,7 +184,7 @@ type(modelist_t), target :: ma_list(0:N_DIAG) ! list of aerosol modes used in cl
 
 
 ! values for constituents with requested value of zero
-real(r8), allocatable, target :: zero_cols(:,:) 
+real(r8), allocatable, target :: zero_cols(:,:)
 
 ! define generic interface routines
 interface rad_cnst_get_info
@@ -299,7 +299,7 @@ subroutine rad_cnst_readnl(nlfile)
 
    ! Mode definition stings
    call parse_mode_defs(mode_defs, modes)
-   
+
    ! Lists of externally mixed entities for climate and diagnostic calculations
    do i = 0,N_DIAG
       select case (i)
@@ -331,7 +331,7 @@ subroutine rad_cnst_readnl(nlfile)
    ! were there any constituents specified for the nth diagnostic call?
    ! if so, radiation will make a call with those consituents
    active_calls(:) = (namelist(:)%ncnst > 0)
-   	
+
    ! Initialize the gas and aerosol lists with the information from the
    ! namelist.  This is done here so that this information is available via
    ! the query functions at the time when the register methods are called.
@@ -470,13 +470,13 @@ subroutine rad_cnst_get_gas(list_idx, gasname, state, pbuf, mmr)
       write(iulog,*) subname//': list_idx =', list_idx
       call endrun(subname//': list_idx out of bounds')
    endif
-      
+
    lchnk = state%lchnk
 
-   ! Get index of gas in internal arrays.  rad_gas_index will abort if the 
+   ! Get index of gas in internal arrays.  rad_gas_index will abort if the
    ! specified gasname is not recognized by the radiative transfer code.
    igas = rad_gas_index(trim(gasname))
- 
+
    ! Get data source
    source = list%gas(igas)%source
    idx    = list%gas(igas)%idx
@@ -516,10 +516,10 @@ function rad_cnst_num_name(list_idx, spc_name_in, num_name_out, mode_out, spec_o
   character(len= 32) :: spec_name
 
   found = .false.
-  
+
   m_list => ma_list(list_idx)
   nmodes = m_list%nmodes
-  
+
   do n = 1,nmodes
      mm = m_list%idx(n)
      nspecs = modes%comps(mm)%nspec
@@ -629,7 +629,7 @@ subroutine rad_cnst_get_info(list_idx, gasnames, aernames, &
 
       ! get index of O3 in gas list
       igas = rad_gas_index('O3')
- 
+
       ! Get data source
       source = g_list%gas(igas)%source
 
@@ -1054,7 +1054,7 @@ subroutine init_mode_comps(modes)
                                                    modes%comps(m)%camname_mmr_c(ispec), routine)
 
          ! get physprop ID
-         modes%comps(m)%idx_props(ispec) = physprop_get_id(modes%comps(m)%props(ispec)) 
+         modes%comps(m)%idx_props(ispec) = physprop_get_id(modes%comps(m)%props(ispec))
          if (modes%comps(m)%idx_props(ispec) == -1) then
             call endrun(routine//' : ERROR idx not found for '//trim(modes%comps(m)%props(ispec)))
          end if
@@ -1079,7 +1079,7 @@ integer function get_cam_idx(source, name, routine)
    integer :: idx
    integer :: errcode
    !-----------------------------------------------------------------------------
-   
+
    if (source(1:1) == 'N') then
 
       idx = pbuf_get_index(trim(name),errcode)
@@ -1103,7 +1103,7 @@ integer function get_cam_idx(source, name, routine)
       call endrun(routine//' ERROR: invalid source for specie '//trim(name))
 
    end if
-  
+
    get_cam_idx = idx
 
 end function get_cam_idx
@@ -1112,7 +1112,7 @@ end function get_cam_idx
 
 subroutine list_init1(namelist, gaslist, aerlist, ma_list)
 
-   ! Initialize the gas and bulk and modal aerosol lists with the 
+   ! Initialize the gas and bulk and modal aerosol lists with the
    ! entities specified in the climate or diagnostic lists.
 
    ! This first phase initialization just sets the information that
@@ -1180,7 +1180,7 @@ subroutine list_init1(namelist, gaslist, aerlist, ma_list)
       end if
 
       ! Add component to appropriate list (gas, modal or bulk aerosol)
-      if (namelist%type(ii) == 'A') then 
+      if (namelist%type(ii) == 'A') then
 
          ! Add to bulk aerosol list
          ba_idx = ba_idx + 1
@@ -1189,7 +1189,7 @@ subroutine list_init1(namelist, gaslist, aerlist, ma_list)
          aerlist%aer(ba_idx)%camname       = namelist%camname(ii)
          aerlist%aer(ba_idx)%physprop_file = namelist%radname(ii)
 
-      else if (namelist%type(ii) == 'M') then 
+      else if (namelist%type(ii) == 'M') then
 
          ! Add to modal aerosol list
          ma_idx = ma_idx + 1
@@ -1209,7 +1209,7 @@ subroutine list_init1(namelist, gaslist, aerlist, ma_list)
          ! Also save the name of the physprop file
          ma_list%physprop_files(ma_idx) = namelist%radname(ii)
 
-      else 
+      else
 
          ! Add to gas list
 
@@ -1388,7 +1388,7 @@ end subroutine rad_aer_diag_init
 subroutine parse_mode_defs(nl_in, modes)
 
    ! Parse the mode definition specifiers.  The specifiers are of the form:
-   ! 
+   !
    ! 'mode_name:mode_type:=',
    !  'source_num_a:camname_num_a:source_num_c:camname_num_c:num_mr:+',
    !  'source_mmr_a:camname_mmr_a:source_mmr_c:camname_mmr_c:spec_type:prop_file[:+]'[,]
@@ -1422,7 +1422,7 @@ subroutine parse_mode_defs(nl_in, modes)
    !              associated field for the prop_file.  There can only be one entry
    !              with the num_mr type in a mode definition.
    ! prop_file -- For aerosol species this is a filename, which is
-   !              identified by a ".nc" suffix.  The file contains optical and 
+   !              identified by a ".nc" suffix.  The file contains optical and
    !              other physical properties of the aerosol.
    !
    ! A mode definition must contain only 1 string for the number mixing ratio components
@@ -1448,7 +1448,7 @@ subroutine parse_mode_defs(nl_in, modes)
    character(len=32) :: tmp_name_c
    character(len=32) :: tmp_type
    !-------------------------------------------------------------------------
-  
+
    ! Determine number of modes defined by counting number of strings that are
    ! terminated by ':='
    ! (algorithm stops counting at first blank element).
@@ -1458,7 +1458,7 @@ subroutine parse_mode_defs(nl_in, modes)
 
       if (len_trim(nl_in(m)) == 0) exit
       nstr = nstr + 1
-      
+
       ! There are no fields in the input strings in which a blank character is allowed.
       ! To simplify the parsing go through the input strings and remove blanks.
       tmpstr = adjustl(nl_in(m))
@@ -1489,7 +1489,7 @@ subroutine parse_mode_defs(nl_in, modes)
       write(iulog,*) routine//': ERROR: cannot allocate storage for modes.  nmodes=', nmodes
       call endrun(routine//': ERROR allocating storage for modes')
    end if
-   
+
 
    mcur = 1              ! index of current string being processed
 
@@ -1512,7 +1512,7 @@ subroutine parse_mode_defs(nl_in, modes)
          nspec = nspec + 1
          mcur = mcur + 1
       end do
-      
+
       ! a mode must have at least one specie
       if (nspec == 0) call parse_error('mode must have at least one specie', nl_in(mbeg))
 
@@ -1549,7 +1549,7 @@ subroutine parse_mode_defs(nl_in, modes)
       ! return to first string in mode definition
       mcur = mbeg
       tmpstr = nl_in(mcur)
-      
+
       ! mode name
       ipos = index(tmpstr, ':')
       if (ipos < 2) call parse_error('mode name not found', tmpstr)
@@ -1693,7 +1693,7 @@ subroutine parse_mode_defs(nl_in, modes)
 
       character(len=*), intent(in) :: str
       integer,          intent(in) :: ib, ie
-   
+
       integer :: i
 
       do i = 1, num_spec_types
@@ -1710,7 +1710,7 @@ subroutine parse_mode_defs(nl_in, modes)
 
       character(len=*), intent(in) :: str
       integer,          intent(in) :: ib, ie  ! begin, end character of mode type substring
-   
+
       integer :: i
 
       do i = 1, num_mode_types
@@ -1739,7 +1739,7 @@ subroutine parse_rad_specifier(specifier, namelist_data)
 ! radname -- For gases this is a name that identifies the constituent to the
 !            radiative transfer codes.  These names are contained in the
 !            radconstants module.  For aerosols this is a filename, which is
-!            identified by a ".nc" suffix.  The file contains optical and 
+!            identified by a ".nc" suffix.  The file contains optical and
 !            other physical properties of the aerosol.
 !
 ! This code also identifies whether the constituent is a gas or an aerosol
@@ -1759,11 +1759,11 @@ subroutine parse_rad_specifier(specifier, namelist_data)
     character(len=cs1) :: radname(n_rad_cnst)
     character(len=1)   :: type(n_rad_cnst)
     !-------------------------------------------------------------------------
-  
+
     number = 0
 
     parse_loop: do i = 1, n_rad_cnst
-      if ( len_trim(specifier(i)) == 0 ) then 
+      if ( len_trim(specifier(i)) == 0 ) then
          exit parse_loop
       endif
 
@@ -1784,12 +1784,12 @@ subroutine parse_rad_specifier(specifier, namelist_data)
 
       ! locate the ':' separating camname from radname
       j = scan(tmpstr, ':')
- 
+
       camname(i) = tmpstr(:j-1)
       radname(i) = tmpstr(j+1:)
 
       ! determine the type of constituent
-      if (source(i) == 'M') then 
+      if (source(i) == 'M') then
          type(i) = 'M'
       else if(index(radname(i),".nc") .gt. 0) then
          type(i) = 'A'
@@ -1797,7 +1797,7 @@ subroutine parse_rad_specifier(specifier, namelist_data)
          type(i) = 'G'
       end if
 
-      number = number+1    
+      number = number+1
     end do parse_loop
 
     namelist_data%ncnst = number
@@ -1822,23 +1822,22 @@ end subroutine parse_rad_specifier
 
 !================================================================================================
 
-subroutine rad_cnst_get_aer_mmr_by_idx(list_idx, aer_idx, state, pbuf, mmr)
+subroutine rad_cnst_get_aer_mmr_by_idx(list_idx, aer_idx, cnst_array, pbuf, mmr)
 
    ! Return pointer to mass mixing ratio for the aerosol from the specified
    ! climate or diagnostic list.
 
    ! Arguments
-   integer,                     intent(in) :: list_idx    ! index of the climate or a diagnostic list
-   integer,                     intent(in) :: aer_idx
-   type(physics_state), target, intent(in) :: state
-   type(physics_buffer_desc), pointer      :: pbuf(:)
-   real(r8),                    pointer    :: mmr(:,:)
+   integer,                   intent(in) :: list_idx ! index of the climate or a diagnostic list
+   integer,                   intent(in) :: aer_idx
+   real(r8),          target, intent(in) :: cnst_array(:,:,:)
+   type(physics_buffer_desc), pointer    :: pbuf(:)
+   real(r8),                  pointer    :: mmr(:,:)
 
    ! Local variables
-   integer :: lchnk
-   integer :: idx
-   character(len=1) :: source
-   type(aerlist_t), pointer :: aerlist
+   integer                     :: idx
+   character(len=1)            :: source
+   type(aerlist_t),  pointer   :: aerlist
    character(len=*), parameter :: subname = 'rad_cnst_get_aer_mmr_by_idx'
    !-----------------------------------------------------------------------------
 
@@ -1848,8 +1847,6 @@ subroutine rad_cnst_get_aer_mmr_by_idx(list_idx, aer_idx, state, pbuf, mmr)
       write(iulog,*) subname//': list_idx =', list_idx
       call endrun(subname//': list_idx out of bounds')
    endif
-
-   lchnk = state%lchnk
 
    ! Check for valid input aerosol index
    if (aer_idx < 1  .or.  aer_idx > aerlist%numaerosols) then
@@ -1862,7 +1859,7 @@ subroutine rad_cnst_get_aer_mmr_by_idx(list_idx, aer_idx, state, pbuf, mmr)
    idx    = aerlist%aer(aer_idx)%idx
    select case( source )
    case ('A')
-      mmr => state%q(:,:,idx)
+      mmr => cnst_array(:,:,idx)
    case ('N')
       call pbuf_get_field(pbuf, idx, mmr)
    case ('Z')
@@ -1873,26 +1870,25 @@ end subroutine rad_cnst_get_aer_mmr_by_idx
 
 !================================================================================================
 
-subroutine rad_cnst_get_mam_mmr_by_idx(list_idx, mode_idx, spec_idx, phase, state, pbuf, mmr)
+subroutine rad_cnst_get_mam_mmr_by_idx(list_idx, mode_idx, spec_idx, phase, cnst_array, pbuf, mmr)
 
    ! Return pointer to mass mixing ratio for the modal aerosol specie from the specified
-   ! climate or diagnostic list.  
+   ! climate or diagnostic list.
 
    ! Arguments
-   integer,                     intent(in) :: list_idx    ! index of the climate or a diagnostic list
-   integer,                     intent(in) :: mode_idx    ! mode index
-   integer,                     intent(in) :: spec_idx    ! index of specie in the mode
-   character(len=1),            intent(in) :: phase       ! 'a' for interstitial, 'c' for cloud borne
-   type(physics_state), target, intent(in) :: state
-   type(physics_buffer_desc),   pointer    :: pbuf(:)
-   real(r8),                    pointer    :: mmr(:,:)
+   integer,                   intent(in) :: list_idx    ! index of the climate or a diagnostic list
+   integer,                   intent(in) :: mode_idx    ! mode index
+   integer,                   intent(in) :: spec_idx    ! index of specie in the mode
+   character(len=1),          intent(in) :: phase       ! 'a' for interstitial, 'c' for cloud borne
+   real(r8),          target, intent(in) :: cnst_array(:,:,:)
+   type(physics_buffer_desc), pointer    :: pbuf(:)
+   real(r8),                  pointer    :: mmr(:,:)
 
    ! Local variables
-   integer :: m_idx
-   integer :: idx
-   integer :: lchnk
-   character(len=1) :: source
-   type(modelist_t), pointer :: mlist
+   integer                     :: m_idx
+   integer                     :: idx
+   character(len=1)            :: source
+   type(modelist_t), pointer   :: mlist
    character(len=*), parameter :: subname = 'rad_cnst_get_mam_mmr_by_idx'
    !-----------------------------------------------------------------------------
 
@@ -1930,11 +1926,9 @@ subroutine rad_cnst_get_mam_mmr_by_idx(list_idx, mode_idx, spec_idx, phase, stat
       call endrun(subname//': unrecognized phase; must be "a" or "c"')
    end if
 
-   lchnk = state%lchnk
-
    select case( source )
    case ('A')
-      mmr => state%q(:,:,idx)
+      mmr => cnst_array(:,:,idx)
    case ('N')
       call pbuf_get_field(pbuf, idx, mmr)
    case ('Z')
@@ -1950,7 +1944,7 @@ subroutine rad_cnst_get_mam_mmr_idx(mode_idx, spec_idx, idx)
    ! Return constituent index of mam specie mass mixing ratio for aerosol modes in
    ! the climate list.
 
-   ! This is a special routine to allow direct access to information in the 
+   ! This is a special routine to allow direct access to information in the
    ! constituent array inside physics parameterizations that have been passed,
    ! and are operating over the entire constituent array.  The interstitial phase
    ! is assumed since that's what is contained in the constituent array.
@@ -1991,25 +1985,24 @@ end subroutine rad_cnst_get_mam_mmr_idx
 
 !================================================================================================
 
-subroutine rad_cnst_get_mode_num(list_idx, mode_idx, phase, state, pbuf, num)
+subroutine rad_cnst_get_mode_num(list_idx, mode_idx, phase, cnst_array, pbuf, num)
 
    ! Return pointer to number mixing ratio for the aerosol mode from the specified
-   ! climate or diagnostic list.  
+   ! climate or diagnostic list.
 
    ! Arguments
-   integer,                     intent(in) :: list_idx    ! index of the climate or a diagnostic list
-   integer,                     intent(in) :: mode_idx    ! mode index
-   character(len=1),            intent(in) :: phase       ! 'a' for interstitial, 'c' for cloud borne
-   type(physics_state), target, intent(in) :: state
-   type(physics_buffer_desc),   pointer    :: pbuf(:)
-   real(r8),                    pointer    :: num(:,:)
+   integer,                   intent(in) :: list_idx ! index of the climate or a diagnostic list
+   integer,                   intent(in) :: mode_idx ! mode index
+   character(len=1),          intent(in) :: phase    ! 'a' for interstitial, 'c' for cloud borne
+   real(r8),          target, intent(in) :: cnst_array(:,:,:)
+   type(physics_buffer_desc), pointer    :: pbuf(:)
+   real(r8),                  pointer    :: num(:,:)
 
    ! Local variables
-   integer :: m_idx
-   integer :: idx
-   integer :: lchnk
-   character(len=1) :: source
-   type(modelist_t), pointer :: mlist
+   integer                     :: m_idx
+   integer                     :: idx
+   character(len=1)            :: source
+   type(modelist_t), pointer   :: mlist
    character(len=*), parameter :: subname = 'rad_cnst_get_mode_num'
    !-----------------------------------------------------------------------------
 
@@ -2041,11 +2034,9 @@ subroutine rad_cnst_get_mode_num(list_idx, mode_idx, phase, state, pbuf, num)
       call endrun(subname//': unrecognized phase; must be "a" or "c"')
    end if
 
-   lchnk = state%lchnk
-
    select case( source )
    case ('A')
-      num => state%q(:,:,idx)
+      num => cnst_array(:,:,idx)
    case ('N')
       call pbuf_get_field(pbuf, idx, num)
    case ('Z')
@@ -2061,7 +2052,7 @@ subroutine rad_cnst_get_mode_num_idx(mode_idx, cnst_idx)
    ! Return constituent index of mode number mixing ratio for the aerosol mode in
    ! the climate list.
 
-   ! This is a special routine to allow direct access to information in the 
+   ! This is a special routine to allow direct access to information in the
    ! constituent array inside physics parameterizations that have been passed,
    ! and are operating over the entire constituent array.  The interstitial phase
    ! is assumed since that's what is contained in the constituent array.
@@ -2116,7 +2107,7 @@ integer function rad_cnst_get_aer_idx(list_idx, aer_name)
    type(aerlist_t), pointer :: aerlist
    character(len=*), parameter :: subname = "rad_cnst_get_aer_idx"
    !-------------------------------------------------------------------------
-   
+
    if (list_idx >= 0 .and. list_idx <= N_DIAG) then
       aerlist => aerosollist(list_idx)
    else
@@ -2134,7 +2125,7 @@ integer function rad_cnst_get_aer_idx(list_idx, aer_name)
    end do
 
    if (aer_idx == -1) call endrun(subname//": ERROR - name not found")
-  
+
    rad_cnst_get_aer_idx = aer_idx
 
 end function rad_cnst_get_aer_idx
@@ -2160,30 +2151,30 @@ subroutine rad_cnst_get_aer_props_by_idx(list_idx, &
    integer,                     intent(in)  :: list_idx ! index of the climate or a diagnostic list
    integer,                     intent(in)  :: aer_idx  ! index of the aerosol
    character(len=ot_length), optional, intent(out) :: opticstype
-   real(r8),          optional, pointer     :: sw_hygro_ext(:,:) 
-   real(r8),          optional, pointer     :: sw_hygro_ssa(:,:) 
-   real(r8),          optional, pointer     :: sw_hygro_asm(:,:) 
-   real(r8),          optional, pointer     :: lw_hygro_ext(:,:)         
+   real(r8),          optional, pointer     :: sw_hygro_ext(:,:)
+   real(r8),          optional, pointer     :: sw_hygro_ssa(:,:)
+   real(r8),          optional, pointer     :: sw_hygro_asm(:,:)
+   real(r8),          optional, pointer     :: lw_hygro_ext(:,:)
    real(r8),          optional, pointer     :: sw_nonhygro_ext(:)
    real(r8),          optional, pointer     :: sw_nonhygro_ssa(:)
    real(r8),          optional, pointer     :: sw_nonhygro_asm(:)
    real(r8),          optional, pointer     :: sw_nonhygro_scat(:)
    real(r8),          optional, pointer     :: sw_nonhygro_ascat(:)
-   real(r8),          optional, pointer     :: lw_ext(:)         
+   real(r8),          optional, pointer     :: lw_ext(:)
    complex(r8),       optional, pointer     :: refindex_aer_sw(:)
    complex(r8),       optional, pointer     :: refindex_aer_lw(:)
-   character(len=20), optional, intent(out) :: aername           
+   character(len=20), optional, intent(out) :: aername
    real(r8),          optional, intent(out) :: density_aer
    real(r8),          optional, intent(out) :: hygro_aer
-   real(r8),          optional, intent(out) :: dryrad_aer        
-   real(r8),          optional, intent(out) :: dispersion_aer    
-   real(r8),          optional, intent(out) :: num_to_mass_aer   
+   real(r8),          optional, intent(out) :: dryrad_aer
+   real(r8),          optional, intent(out) :: dispersion_aer
+   real(r8),          optional, intent(out) :: num_to_mass_aer
 
-   real(r8),          optional, pointer     :: r_sw_ext(:,:)         
-   real(r8),          optional, pointer     :: r_sw_scat(:,:)         
-   real(r8),          optional, pointer     :: r_sw_ascat(:,:)         
-   real(r8),          optional, pointer     :: r_lw_abs(:,:)         
-   real(r8),          optional, pointer     :: mu(:)         
+   real(r8),          optional, pointer     :: r_sw_ext(:,:)
+   real(r8),          optional, pointer     :: r_sw_scat(:,:)
+   real(r8),          optional, pointer     :: r_sw_ascat(:,:)
+   real(r8),          optional, pointer     :: r_lw_abs(:,:)
+   real(r8),          optional, pointer     :: mu(:)
 
    ! Local variables
    integer :: id
@@ -2259,31 +2250,31 @@ subroutine rad_cnst_get_mam_props_by_idx(list_idx, &
    integer,                     intent(in)  :: mode_idx  ! mode index
    integer,                     intent(in)  :: spec_idx  ! index of specie in the mode
    character(len=ot_length), optional, intent(out) :: opticstype
-   real(r8),          optional, pointer     :: sw_hygro_ext(:,:) 
-   real(r8),          optional, pointer     :: sw_hygro_ssa(:,:) 
-   real(r8),          optional, pointer     :: sw_hygro_asm(:,:) 
-   real(r8),          optional, pointer     :: lw_hygro_ext(:,:)         
+   real(r8),          optional, pointer     :: sw_hygro_ext(:,:)
+   real(r8),          optional, pointer     :: sw_hygro_ssa(:,:)
+   real(r8),          optional, pointer     :: sw_hygro_asm(:,:)
+   real(r8),          optional, pointer     :: lw_hygro_ext(:,:)
    real(r8),          optional, pointer     :: sw_nonhygro_ext(:)
    real(r8),          optional, pointer     :: sw_nonhygro_ssa(:)
    real(r8),          optional, pointer     :: sw_nonhygro_asm(:)
    real(r8),          optional, pointer     :: sw_nonhygro_scat(:)
    real(r8),          optional, pointer     :: sw_nonhygro_ascat(:)
-   real(r8),          optional, pointer     :: lw_ext(:)         
+   real(r8),          optional, pointer     :: lw_ext(:)
    complex(r8),       optional, pointer     :: refindex_aer_sw(:)
    complex(r8),       optional, pointer     :: refindex_aer_lw(:)
 
-   real(r8),          optional, pointer     :: r_sw_ext(:,:)         
-   real(r8),          optional, pointer     :: r_sw_scat(:,:)         
-   real(r8),          optional, pointer     :: r_sw_ascat(:,:)         
-   real(r8),          optional, pointer     :: r_lw_abs(:,:)         
-   real(r8),          optional, pointer     :: mu(:)         
+   real(r8),          optional, pointer     :: r_sw_ext(:,:)
+   real(r8),          optional, pointer     :: r_sw_scat(:,:)
+   real(r8),          optional, pointer     :: r_sw_ascat(:,:)
+   real(r8),          optional, pointer     :: r_lw_abs(:,:)
+   real(r8),          optional, pointer     :: mu(:)
 
-   character(len=20), optional, intent(out) :: aername           
+   character(len=20), optional, intent(out) :: aername
    real(r8),          optional, intent(out) :: density_aer
    real(r8),          optional, intent(out) :: hygro_aer
-   real(r8),          optional, intent(out) :: dryrad_aer        
-   real(r8),          optional, intent(out) :: dispersion_aer    
-   real(r8),          optional, intent(out) :: num_to_mass_aer   
+   real(r8),          optional, intent(out) :: dryrad_aer
+   real(r8),          optional, intent(out) :: dispersion_aer
+   real(r8),          optional, intent(out) :: num_to_mass_aer
    character(len=32), optional, intent(out) :: spectype
 
    ! Local variables

--- a/src/physics/cam/radiation_data.F90
+++ b/src/physics/cam/radiation_data.F90
@@ -93,8 +93,8 @@ module radiation_data
   integer :: ngas, naer=0
   character(len=64), allocatable :: gasnames(:)
   character(len=64), allocatable :: aernames(:)
- 
-  ! control options  
+
+  ! control options
   logical          :: rad_data_output = .false.
   integer          :: rad_data_histfile_num = 2
   character(len=1) :: rad_data_avgflag = 'I'
@@ -125,10 +125,10 @@ contains
 
     if ( do_fdh ) then
       call pbuf_add_field('tcorr', 'global',  dtype_r8, (/pcols,pver/), tcorr_idx)
-      call pbuf_add_field('qrsin', 'physpkg', dtype_r8, (/pcols,pver/), qrsin_idx) 
-      call pbuf_add_field('qrlin', 'physpkg', dtype_r8, (/pcols,pver/), qrlin_idx) 
-      call pbuf_add_field('tropp', 'physpkg', dtype_r8, (/pcols/),      tropp_idx) 
-    end if 
+      call pbuf_add_field('qrsin', 'physpkg', dtype_r8, (/pcols,pver/), qrsin_idx)
+      call pbuf_add_field('qrlin', 'physpkg', dtype_r8, (/pcols,pver/), qrlin_idx)
+      call pbuf_add_field('tropp', 'physpkg', dtype_r8, (/pcols/),      tropp_idx)
+    end if
 
   end subroutine rad_data_register
 
@@ -192,7 +192,7 @@ contains
     use physics_buffer, only: pbuf_get_index
     use physics_buffer, only: pbuf_set_field
     implicit none
-    
+
     ! args
     type(physics_buffer_desc), pointer :: pbuf2d(:,:)
 
@@ -205,7 +205,7 @@ contains
     character(len=64) :: long_name_description
     character(len=16)  :: microp_scheme  ! microphysics scheme
     character(len=16)  :: rad_scheme
-   
+
     if (.not.enabled) return
 
     call phys_getopts(microp_scheme_out=microp_scheme, radiation_scheme_out=rad_scheme)
@@ -249,7 +249,7 @@ contains
        nmxrgn_ifld = pbuf_get_index('NMXRGN')
        pmxrgn_ifld = pbuf_get_index('PMXRGN')
     endif
-    
+
     if ( do_fdh ) then
        call addfld('rad_TROP_P', horiz_only,  'A','Pa','Pressure at which tropopause is defined for radiation' )
        call addfld('rad_TCORR',  (/ 'lev' /), 'I','K', 'Fixed dynamical heating temperature correction ' )
@@ -263,7 +263,7 @@ contains
 
     ! The code to output the gases assumes that the rad_constituents module has
     ! ordered them in the same way that they are ordered in the "gaslist" array
-    ! in module radconstants, and that there are nradgas of them.  This ordering 
+    ! in module radconstants, and that there are nradgas of them.  This ordering
     ! is performed in the internal init_lists routine in rad_constituents.
     if (ngas /= nradgas) then
        call endrun('rad_data_init: ERROR: ngas /= nradgas')
@@ -314,7 +314,7 @@ contains
          'radiation input: long wave direct albedo weighted by coszen',       flag_xyfill=.true.)
     call addfld (aldif_pos_fldn, horiz_only,   rad_data_avgflag, '1',        &
          'radiation input: long wave difuse albedo weighted by coszen',       flag_xyfill=.true.)
-    
+
     call addfld (lwup_fldn,      horiz_only,   rad_data_avgflag, 'W/m2',     &
          'radiation input: long wave up radiation flux ')
     call addfld (ts_fldn,        horiz_only,   rad_data_avgflag, 'K',        &
@@ -415,7 +415,7 @@ contains
     call add_default (rei_fldn,       rad_data_histfile_num, ' ')
     call add_default (qrs_fldn,       rad_data_histfile_num, ' ')
     call add_default (qrl_fldn,       rad_data_histfile_num, ' ')
-    
+
     if (mg_microphys) then
        call add_default (dei_fldn,       rad_data_histfile_num, ' ')
        call add_default (des_fldn,       rad_data_histfile_num, ' ')
@@ -454,7 +454,7 @@ contains
        call addfld(trim(name), (/ 'lev' /), rad_data_avgflag, 'kg/kg', trim(long_name))
        call add_default (trim(name), rad_data_histfile_num, ' ')
     end do
-    
+
     if (naer > 0) then
 
        do i = 1, naer
@@ -500,7 +500,7 @@ contains
   subroutine rad_data_write(  pbuf, state, cam_in, coszen )
 
     use physics_types,    only: physics_state
-    use camsrfexch,       only: cam_in_t     
+    use camsrfexch,       only: cam_in_t
     use constituents,     only: cnst_get_ind
     use physics_buffer,   only: pbuf_get_field, pbuf_old_tim_idx
     use drv_input_data,   only: drv_input_data_freq
@@ -508,7 +508,7 @@ contains
 
     implicit none
     type(physics_buffer_desc), pointer :: pbuf(:)
-    
+
     type(physics_state), intent(in), target :: state
     type(cam_in_t),      intent(in) :: cam_in
     real(r8),            intent(in) :: coszen(pcols)
@@ -524,7 +524,7 @@ contains
     integer :: ixcldliq              ! cloud liquid water index
     integer :: icol
     integer :: ncol
-    
+
     ! surface albedoes weighted by (positive cosine zenith angle)
     real(r8):: coszrs_pos(pcols)    ! = max(coszrs,0)
     real(r8):: asdir_pos (pcols)    !
@@ -547,7 +547,7 @@ contains
     real(r8), pointer, dimension(:,:,:) :: qaerwat_ptr
 
     if (.not.enabled) return
-    call pbuf_get_field(pbuf, qrs_ifld, qrs )    
+    call pbuf_get_field(pbuf, qrs_ifld, qrs )
     call pbuf_get_field(pbuf, qrl_ifld, qrl )
 
     lchnk = state%lchnk
@@ -555,7 +555,7 @@ contains
 
    ! store temperature correction above tropopause in pbuf for Fixed Dynamical Heating
     if(do_fdh) then
-       
+
        call pbuf_get_field(pbuf, tcorr_idx, tcorr)
        call pbuf_get_field(pbuf, qrsin_idx, qrsin)
        call pbuf_get_field(pbuf, qrlin_idx, qrlin)
@@ -563,7 +563,7 @@ contains
        do k = 1, pver
           do i = 1, ncol
              if ( state%pmid(i,k) < tropp(i)) then
-                tcorr(i,k) = tcorr(i,k) + drv_input_data_freq*(qrs(i,k) - qrsin(i,k) + qrl(i,k) - qrlin(i,k)) /cpair 
+                tcorr(i,k) = tcorr(i,k) + drv_input_data_freq*(qrs(i,k) - qrsin(i,k) + qrl(i,k) - qrlin(i,k)) /cpair
              endif
           enddo
        enddo
@@ -627,29 +627,29 @@ contains
 
     call pbuf_get_field(pbuf, rei_ifld,    ptr )
     call outfld(rei_fldn,    ptr, pcols, lchnk )
-    
+
     if (mg_microphys) then
 
        call pbuf_get_field(pbuf,  dei_ifld, ptr     )
-       call outfld(dei_fldn,      ptr, pcols, lchnk   )       
+       call outfld(dei_fldn,      ptr, pcols, lchnk   )
 
        call pbuf_get_field(pbuf,  des_ifld, ptr     )
-       call outfld(des_fldn,      ptr, pcols, lchnk   )       
+       call outfld(des_fldn,      ptr, pcols, lchnk   )
 
        call pbuf_get_field(pbuf,  mu_ifld, ptr      )
-       call outfld(mu_fldn,       ptr, pcols, lchnk   ) 
+       call outfld(mu_fldn,       ptr, pcols, lchnk   )
 
        call pbuf_get_field(pbuf,  lambdac_ifld, ptr )
-       call outfld(lambdac_fldn,  ptr, pcols, lchnk   )       
+       call outfld(lambdac_fldn,  ptr, pcols, lchnk   )
 
        call pbuf_get_field(pbuf,  iciwp_ifld, ptr   )
-       call outfld(iciwp_fldn,    ptr, pcols, lchnk   )       
+       call outfld(iciwp_fldn,    ptr, pcols, lchnk   )
 
        call pbuf_get_field(pbuf,  iclwp_ifld, ptr   )
-       call outfld(iclwp_fldn,    ptr, pcols, lchnk   )       
+       call outfld(iclwp_fldn,    ptr, pcols, lchnk   )
 
        call pbuf_get_field(pbuf,  icswp_ifld, ptr   )
-       call outfld(icswp_fldn,    ptr, pcols, lchnk   )       
+       call outfld(icswp_fldn,    ptr, pcols, lchnk   )
 
        call pbuf_get_field(pbuf,  cldfsnow_ifld, ptr, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
        call outfld(cldfsnow_fldn, ptr, pcols, lchnk   )
@@ -677,7 +677,7 @@ contains
 
     endif
 
-    ! output mixing ratio of rad constituents 
+    ! output mixing ratio of rad constituents
 
     do i = 1, ngas
        name = 'rad_'//gasnames(i)
@@ -689,7 +689,7 @@ contains
        ! bulk aerosol model
        do i = 1, naer
           name = 'rad_'//aernames(i)
-          call rad_cnst_get_aer_mmr(0, i, state, pbuf, mmr)
+          call rad_cnst_get_aer_mmr(0, i, state%q, pbuf, mmr)
           call outfld(trim(name), mmr, pcols, lchnk)
        end do
     endif
@@ -710,7 +710,7 @@ contains
           ! aerosol species loop
           do l = 1, nspec
              call rad_cnst_get_info(0,m,l, spec_name=aername)
-             call rad_cnst_get_aer_mmr(0, m, l, 'a', state, pbuf, mmr)
+             call rad_cnst_get_aer_mmr(0, m, l, 'a', state%q, pbuf, mmr)
              name = 'rad_'//aername
              call outfld(trim(name), mmr, pcols, lchnk)
           enddo
@@ -901,7 +901,7 @@ contains
 
     enddo
 
-    
+
     if (nmodes>0) then
        call get_aeromode_data( indata, dgnumwet_fldn, recno, dgnumwet_ptrs )
        call get_aeromode_data( indata, qaerwat_fldn, recno, qaerwat_ptrs )
@@ -1059,7 +1059,7 @@ contains
 
     !-----------------------------------------------------------------------------
 
-    ! read in mixing ratio of rad constituents 
+    ! read in mixing ratio of rad constituents
 
     do i = 1,ngas
        call read_rad_gas_data(indata, gasnames(i), i, state, pbuf2d, recno )
@@ -1068,7 +1068,7 @@ contains
     do i = 1,naer
        call read_rad_aer_data(indata, aernames(i), i, state, pbuf2d, recno )
     enddo
-    
+
     ! aerosol mode loop
     do m = 1, nmodes
 
@@ -1139,7 +1139,7 @@ contains
     do c = begchunk,endchunk
        ncol = state(c)%ncol
        phys_buffer_chunk => pbuf_get_chunk(pbuf2d, c)
-       call rad_cnst_get_aer_mmr(0, idx, state(c), phys_buffer_chunk, mmr_ptr)
+       call rad_cnst_get_aer_mmr(0, idx, state(c)%q, phys_buffer_chunk, mmr_ptr)
        mmr_ptr(:ncol,:) = mass(:ncol,:,c)
     enddo
 
@@ -1171,7 +1171,7 @@ contains
     do c = begchunk,endchunk
        ncol = state(c)%ncol
        phys_buffer_chunk => pbuf_get_chunk(pbuf2d, c)
-       call rad_cnst_get_aer_mmr(0, mode_idx, spec_idx, 'a', state(c), phys_buffer_chunk, mmr_ptr)
+       call rad_cnst_get_aer_mmr(0, mode_idx, spec_idx, 'a', state(c)%q, phys_buffer_chunk, mmr_ptr)
        mmr_ptr(:ncol,:) = mass(:ncol,:,c)
     enddo
 

--- a/src/physics/cam/zm_conv_intr.F90
+++ b/src/physics/cam/zm_conv_intr.F90
@@ -11,7 +11,7 @@ module zm_conv_intr
    use physconst,    only: cpair
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
    use zm_conv,      only: zm_conv_evap, zm_convr, convtran, momtran
-   
+
    use zm_microphysics,  only: zm_aero_t, zm_conv_t
    use rad_constituents, only: rad_cnst_get_info, rad_cnst_get_mode_num, rad_cnst_get_aer_mmr, &
                                rad_cnst_get_aer_props, rad_cnst_get_mode_props !, &
@@ -233,7 +233,7 @@ subroutine zm_conv_readnl(nlfile)
    call mpi_bcast(zmconv_capelmt,           1, mpi_real8, masterprocid, mpicom, ierr)
    if (ierr /= 0) call endrun("zm_conv_readnl: FATAL: mpi_bcast: zmconv_capelmt")
    call mpi_bcast(zmconv_parcel_pbl,        1, mpi_logical, masterprocid, mpicom, ierr)
-   if (ierr /= 0) call endrun("zm_conv_readnl: FATAL: mpi_bcast: zmconv_parcel_pbl") 
+   if (ierr /= 0) call endrun("zm_conv_readnl: FATAL: mpi_bcast: zmconv_parcel_pbl")
    call mpi_bcast(zmconv_tau,               1, mpi_real8, masterprocid, mpicom, ierr)
    if (ierr /= 0) call endrun("zm_conv_readnl: FATAL: mpi_bcast: zmconv_tau")
 
@@ -623,11 +623,11 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
          ! (list 0)
 
          do m = 1, nmodes
-            call rad_cnst_get_mode_num(0, m, 'a', state, pbuf, aero(lchnk)%num_a(m)%val)
+            call rad_cnst_get_mode_num(0, m, 'a', state%q, pbuf, aero(lchnk)%num_a(m)%val)
             call pbuf_get_field(pbuf, dgnum_idx, aero(lchnk)%dgnum(m)%val, start=(/1,1,m/), kount=(/pcols,pver,1/))
 
             do l = 1, aero(lchnk)%nspec(m)
-               call rad_cnst_get_aer_mmr(0, m, l, 'a', state, pbuf, aero(lchnk)%mmr_a(l,m)%val)
+               call rad_cnst_get_aer_mmr(0, m, l, 'a', state%q, pbuf, aero(lchnk)%mmr_a(l,m)%val)
             end do
          end do
 
@@ -637,7 +637,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
          ! (list 0)
 
          do m = 1, nbulk
-            call rad_cnst_get_aer_mmr(0, m, state, pbuf, aero(lchnk)%mmr_bulk(m)%val)
+            call rad_cnst_get_aer_mmr(0, m, state%q, pbuf, aero(lchnk)%mmr_bulk(m)%val)
          end do
 
       end if


### PR DESCRIPTION
In order to move towards modular aerosol model in a manner consistent with planned CAM infrastructure changes, explicitly pass in CAM constituent array to aerosol routines which require access to aerosol species which are advected.