### PR TITLE
test: regrid lat and lon points for plotting

### DIFF
--- a/src/utils/ctem_diags_mod.F90
+++ b/src/utils/ctem_diags_mod.F90
@@ -244,6 +244,8 @@ contains
     real(r8), target :: t_phys(pver,pcols,begchunk:endchunk)
     real(r8), target :: p_phys(pver,pcols,begchunk:endchunk)
     real(r8) :: ps_phys(pcols,begchunk:endchunk)
+    real(r8) :: lat_phys(pcols,begchunk:endchunk)
+    real(r8) :: lon_phys(pcols,begchunk:endchunk)
 
     real(r8), target :: u_lonlat(beglon:endlon,beglat:endlat,pver)
     real(r8), target :: v_lonlat(beglon:endlon,beglat:endlat,pver)
@@ -251,6 +253,8 @@ contains
     real(r8), target :: t_lonlat(beglon:endlon,beglat:endlat,pver)
     real(r8), target :: p_lonlat(beglon:endlon,beglat:endlat,pver)
     real(r8) :: ps_lonlat(beglon:endlon,beglat:endlat)
+    real(r8) :: lat_lonlat(beglon:endlon,beglat:endlat)
+    real(r8) :: lon_lonlat(beglon:endlon,beglat:endlat)
     real(r8) :: mskind1(beglon:endlon,beglat:endlat) ! vertical index where mountain masking begins
 
     real(r8) :: ui_lonlat(beglon:endlon,beglat:endlat,pver)
@@ -317,6 +321,8 @@ contains
           p_phys(:,i,lchnk) = phys_state(lchnk)%pmid(i,:)
 
           ps_phys(i,lchnk) = phys_state(lchnk)%ps(i)
+          lat_phys(i,lchnk) = phys_state(lchnk)%lat(i)
+          lon_phys(i,lchnk) = phys_state(lchnk)%lon(i)
 
        end do
     end do
@@ -342,6 +348,8 @@ contains
     call esmf_phys2lonlat_regrid(physflds, lonlatflds)
 
     call esmf_phys2lonlat_regrid(ps_phys, ps_lonlat)
+    call esmf_phys2lonlat_regrid(lat_phys, lat_lonlat)
+    call esmf_phys2lonlat_regrid(lon_phys, lon_lonlat)
 
     call t_stopf('ctem_diags_calc-regrid')
 


### PR DESCRIPTION
**DO NOT MERGE**

This is a test branch to help debug issue I am having with the regridding routine.

I have added `lat` and `lon` fields to the regridding routine so I can plot them in a python script.

Below is a plot of the field `ps` on the physics grid and the latlon grid
<img width="708" height="791" alt="image" src="https://github.com/user-attachments/assets/91be6baf-ff7d-4daf-a1c5-1fcd7c1ecec5" />

How do you verify that `ps` is mapped to the lat lon grid correctly?

**steps to reproduce**
- checkout this branch in CAM
- create a new case : `./cime/scripts/create_newcase --case /glade/u/home/tmeltzer/cam-fvitt --compset FWHIST --res ne30pg3_ne30pg3_mg17 --project XXXX --machine derecho`
- I submitted a 5 day run (without changes first and in Release mode i.e., DEBUG=FALSE to make debugging quicker)
- Then I use that starting point to run restarts (with DEBUG=TRUE)
- I dump the memory from each process to file so I can plot it in python

Loaded modules for compilation and runtime:

```
$ module list 
Currently Loaded Modules:
  1) cesmdev/1.0   (H,S)   5) craype/2.7.31    9) kokkos/4.2.01        13) hdf5-mpi/1.12.3         17) esmf/8.8.0
  2) ncarenv/24.12 (S)     6) cmake/3.26.6    10) ncarcompilers/1.0.0  14) netcdf-mpi/4.9.2
  3) conda/latest          7) intel/2024.2.1  11) libfabric/1.15.2.0   15) parallel-netcdf/1.14.0
  4) nco/5.3.1             8) mkl/2024.2.2    12) cray-mpich/8.1.29    16) parallelio/2.6.4
```