### PR TITLE
Fix dealloc in aero_model: use aerosol_instances_mod copy

### DIFF
--- a/src/chemistry/bulk_aero/aero_model.F90
+++ b/src/chemistry/bulk_aero/aero_model.F90
@@ -19,7 +19,9 @@ module aero_model
   use physics_buffer,    only: pbuf_get_field, pbuf_get_index
   use cam_history,       only: outfld
   use infnan,            only: nan, assignment(=)
-  use bulk_aerosol_properties_mod, only: bulk_aerosol_properties
+  use aerosol_properties_mod, only: aerosol_properties
+  use aerosol_instances_mod, only: aerosol_instances_get_props, &
+       aerosol_instances_get_state, aerosol_instances_get_num_models
 
   implicit none
   private
@@ -58,7 +60,8 @@ module aero_model
   real(r8) :: aer_sol_factb(pcnst) ! below-cloud solubility factor
   real(r8) :: aer_scav_coef(pcnst)
 
-  type(bulk_aerosol_properties), pointer :: aero_props =>null()
+  class(aerosol_properties), pointer :: aero_props =>null()
+  integer :: iaermod_ = -1
 
 contains
 
@@ -154,7 +157,10 @@ contains
     logical  :: history_aerosol ! Output MAM or SECT aerosol tendencies
     logical  :: history_dust    ! Output dust
 
-    aero_props => bulk_aerosol_properties()
+    do iaermod_ = 1, aerosol_instances_get_num_models()
+       aero_props => aerosol_instances_get_props(iaermod_, 0)
+       if (aero_props%model_is('BAM')) exit
+    end do
 
     ! aqueous chem initialization
     call sox_inti(aero_props)
@@ -1036,7 +1042,6 @@ contains
     use mo_setsox,   only : setsox, has_sox
     use mo_setsoa,   only : setsoa, has_soa
     use aerosol_state_mod, only : aerosol_state
-    use bulk_aerosol_state_mod, only : bulk_aerosol_state
 
     !-----------------------------------------------------------------------
     !      ... dummy arguments
@@ -1079,7 +1084,7 @@ contains
     class(aerosol_state), pointer :: aero_state
 
 !----------------------------------------------------------------------
-    aero_state => bulk_aerosol_state(state, pbuf)
+    aero_state => aerosol_instances_get_state(iaermod_, 0, lchnk)
 
   ! aqueous chemistry ...
 

--- a/src/chemistry/bulk_aero/aero_model.F90
+++ b/src/chemistry/bulk_aero/aero_model.F90
@@ -157,13 +157,15 @@ contains
     logical  :: history_aerosol ! Output MAM or SECT aerosol tendencies
     logical  :: history_dust    ! Output dust
 
+    nullify(aero_props)
     do iaermod_ = 1, aerosol_instances_get_num_models()
        aero_props => aerosol_instances_get_props(iaermod_, 0)
        if (aero_props%model_is('BAM')) exit
+       nullify(aero_props)
     end do
 
     ! aqueous chem initialization
-    call sox_inti(aero_props)
+    if (associated(aero_props)) call sox_inti(aero_props)
 
     call phys_getopts( history_aerosol_out = history_aerosol,&
                        history_dust_out    = history_dust   )
@@ -1084,7 +1086,8 @@ contains
     class(aerosol_state), pointer :: aero_state
 
 !----------------------------------------------------------------------
-    aero_state => aerosol_instances_get_state(iaermod_, 0, lchnk)
+    nullify(aero_state)
+    if (iaermod_ > 0) aero_state => aerosol_instances_get_state(iaermod_, 0, lchnk)
 
   ! aqueous chemistry ...
 

--- a/src/chemistry/carma_aero/aero_model.F90
+++ b/src/chemistry/carma_aero/aero_model.F90
@@ -23,7 +23,9 @@ module aero_model
                                rad_aer_get_bin_props_by_idx
   use aerosol_mmr_cam,   only: rad_cnst_get_bin_mmr_by_idx
   use mo_setsox,         only: setsox, has_sox
-  use carma_aerosol_properties_mod, only: carma_aerosol_properties
+  use aerosol_properties_mod, only: aerosol_properties
+  use aerosol_instances_mod, only: aerosol_instances_get_props, &
+       aerosol_instances_get_state, aerosol_instances_get_num_models
 
   use carma_intr, only: carma_get_group_by_name, carma_get_dry_radius, carma_get_wet_radius, carma_get_bin_rmass
   use carma_intr, only: carma_get_sad
@@ -76,7 +78,8 @@ module aero_model
 
   logical :: convproc_do_aer
 
-  type(carma_aerosol_properties), pointer :: aero_props =>null()
+  class(aerosol_properties), pointer :: aero_props =>null()
+  integer :: iaermod_ = -1
 
 contains
 
@@ -210,7 +213,10 @@ contains
     integer :: idx, ierr
     real(r8) :: nanval
 
-    aero_props => carma_aerosol_properties()
+    do iaermod_ = 1, aerosol_instances_get_num_models()
+       aero_props => aerosol_instances_get_props(iaermod_, 0)
+       if (aero_props%model_is('CARMA')) exit
+    end do
     call aero_deposition_cam_init(aero_props)
 
     if (is_first_step()) then
@@ -469,7 +475,6 @@ contains
 
     use carma_aero_gasaerexch, only : carma_aero_gasaerexch_sub
     use time_manager,          only : get_nstep
-    use carma_aerosol_state_mod, only : carma_aerosol_state
     use aerosol_state_mod, only: aerosol_state, ptr2d_t
 
     !-----------------------------------------------------------------------
@@ -543,7 +548,7 @@ contains
     class(aerosol_state), pointer :: aero_state
 
 !----------------------------------------------------------------------
-    aero_state => carma_aerosol_state(state, pbuf)
+    aero_state => aerosol_instances_get_state(iaermod_, 0, lchnk)
 
 !
 ! ... initialize nh3
@@ -733,7 +738,6 @@ contains
        end do
     end do
 
-    deallocate(aero_state)
     nullify(aero_state)
 
   end subroutine aero_model_gasaerexch

--- a/src/chemistry/carma_aero/carma_aero_gasaerexch.F90
+++ b/src/chemistry/carma_aero/carma_aero_gasaerexch.F90
@@ -15,7 +15,9 @@ module carma_aero_gasaerexch
   use radiative_aerosol, only: rad_aer_get_info, rad_aer_get_info_by_bin, rad_aer_get_bin_props_by_idx, &
                               rad_aer_get_info_by_bin_spec
   use physics_buffer,   only: physics_buffer_desc, pbuf_get_index, pbuf_get_field
-  use carma_aerosol_properties_mod, only: carma_aerosol_properties
+  use aerosol_properties_mod, only: aerosol_properties
+  use aerosol_instances_mod, only: aerosol_instances_get_props, &
+       aerosol_instances_get_state, aerosol_instances_get_num_models
 
   implicit none
   private
@@ -38,7 +40,8 @@ module carma_aero_gasaerexch
 
   ! local indexing for bins
   integer :: ncnst_tot                  ! total number of mode number conc + mode species
-  type(carma_aerosol_properties), pointer :: aero_props =>null()
+  class(aerosol_properties), pointer :: aero_props =>null()
+  integer :: iaermod_ = -1
 
   real(r8) :: mw_soa = 250._r8
   integer :: fracvbs_idx = -1
@@ -122,7 +125,10 @@ contains
 
     nspec_max = maxval(nspec)
 
-    aero_props => carma_aerosol_properties()
+    do iaermod_ = 1, aerosol_instances_get_num_models()
+       aero_props => aerosol_instances_get_props(iaermod_, 0)
+       if (aero_props%model_is('CARMA')) exit
+    end do
 
     ncnst_tot = aero_props%ncnst_tot()
 
@@ -298,7 +304,7 @@ subroutine carma_aero_gasaerexch_sub(  state, &
   use physconst,         only: gravit, mwdry
   use cam_abortutils,    only: endrun
   use time_manager,      only: is_first_step
-  use carma_aerosol_state_mod, only: carma_aerosol_state
+  use aerosol_state_mod, only: aerosol_state
   use physics_types,     only: physics_state
   use physconst, only: mwdry, rair
 
@@ -396,10 +402,10 @@ subroutine carma_aero_gasaerexch_sub(  state, &
 
   real(r8) :: rhoair(pcols,pver)
   real(r8), pointer :: nmr(:,:)
-  type(carma_aerosol_state), pointer :: aero_state
+  class(aerosol_state), pointer :: aero_state
 
 !----------------------------------------------------------------------
-   aero_state => carma_aerosol_state(state, pbuf)
+   aero_state => aerosol_instances_get_state(iaermod_, 0, lchnk)
 
 !  map CARMA soa to working soa(nbins,nsoa)
 
@@ -699,7 +705,6 @@ subroutine carma_aero_gasaerexch_sub(  state, &
      end if
   end do ! m = ...
 
-  deallocate(aero_state)
   nullify(aero_state)
 
 end subroutine carma_aero_gasaerexch_sub

--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -21,7 +21,9 @@ module chemistry
   use string_utils,        only : to_upper
 #if defined( MODAL_AERO )
   use modal_aero_data,     only : ntot_amode
-  use modal_aerosol_properties_mod, only: modal_aerosol_properties
+  use aerosol_properties_mod, only: aerosol_properties
+  use aerosol_instances_mod, only: aerosol_instances_get_props, &
+       aerosol_instances_get_num_models
 #endif
 
   ! GEOS-Chem derived types
@@ -171,8 +173,7 @@ module chemistry
   logical, parameter :: chem_has_ndep_flx = .false.
 
 #if defined( MODAL_AERO )
-  ! MAM aerosol properties object class
-  type(modal_aerosol_properties), pointer :: aero_props=>null()
+  class(aerosol_properties), pointer :: aero_props=>null()
 #endif
 contains
 
@@ -1578,8 +1579,14 @@ contains
     ENDIF
 
 #if defined( MODAL_AERO )
-    ! instantiate MAM aerosol properties object
-    aero_props => modal_aerosol_properties()
+    ! retrieve MAM aerosol properties from aerosol instances
+    block
+      integer :: iaermod
+      do iaermod = 1, aerosol_instances_get_num_models()
+         aero_props => aerosol_instances_get_props(iaermod, 0)
+         if (aero_props%model_is('MAM')) exit
+      end do
+    end block
 
     ! Initialize aqueous chem
     CALL SOx_inti(aero_props)

--- a/src/chemistry/geoschem/chemistry.F90
+++ b/src/chemistry/geoschem/chemistry.F90
@@ -1048,6 +1048,7 @@ contains
     INTEGER                :: I, J, L, N, M
     INTEGER                :: RC
     INTEGER                :: nLinoz
+    integer                :: iaermod
 
     ! Logicals
     LOGICAL                :: prtDebug
@@ -1580,13 +1581,10 @@ contains
 
 #if defined( MODAL_AERO )
     ! retrieve MAM aerosol properties from aerosol instances
-    block
-      integer :: iaermod
-      do iaermod = 1, aerosol_instances_get_num_models()
-         aero_props => aerosol_instances_get_props(iaermod, 0)
-         if (aero_props%model_is('MAM')) exit
-      end do
-    end block
+    do iaermod = 1, aerosol_instances_get_num_models()
+       aero_props => aerosol_instances_get_props(iaermod, 0)
+       if (aero_props%model_is('MAM')) exit
+    end do
 
     ! Initialize aqueous chem
     CALL SOx_inti(aero_props)

--- a/src/chemistry/modal_aero/aero_model.F90
+++ b/src/chemistry/modal_aero/aero_model.F90
@@ -29,9 +29,10 @@ module aero_model
 
   use modal_aero_wateruptake, only: modal_strat_sulfate
   use mo_setsox,              only: setsox, has_sox
-  use modal_aerosol_properties_mod, only: modal_aerosol_properties
-  use modal_aerosol_state_mod, only: modal_aerosol_state
+  use aerosol_properties_mod, only: aerosol_properties
   use aerosol_state_mod, only: aerosol_state
+  use aerosol_instances_mod, only: aerosol_instances_get_props, &
+       aerosol_instances_get_state, aerosol_instances_get_num_models
 
   implicit none
   private
@@ -101,7 +102,8 @@ module aero_model
 
   logical :: modal_accum_coarse_exch = .false.
 
-  type(modal_aerosol_properties), pointer :: aero_props=>null()
+  class(aerosol_properties), pointer :: aero_props=>null()
+  integer :: iaermod_ = -1
 
   integer :: n_coarse_dust=-1 ! dmleung added n_coarse_dust to determine the index for the
                               ! coarse dust mode for different MAM versions. 29 Oct 2025
@@ -222,7 +224,10 @@ contains
     integer :: mm
     character(len=32) :: name_a, name_c
 
-    aero_props => modal_aerosol_properties()
+    do iaermod_ = 1, aerosol_instances_get_num_models()
+       aero_props => aerosol_instances_get_props(iaermod_, 0)
+       if (aero_props%model_is('MAM')) exit
+    end do
     ncnst_tot = aero_props%ncnst_tot()
 
     ! aqueous chem initialization
@@ -1067,7 +1072,7 @@ contains
     character(len=32) :: specname
     class(aerosol_state), pointer :: aero_state
 
-    aero_state => modal_aerosol_state(state, pbuf)
+    aero_state => aerosol_instances_get_state(iaermod_, 0, lchnk)
 !
 ! ... initialize nh3
 !


### PR DESCRIPTION
This uses `aerosol_instances_mod` to get already created copies of `aero_props` and `aero_state` so the callers in `aero_model` do not need to construct their own - this would also fix a memory leak of `aero_state` in the bulk/modal gas-aerosol exchange subroutine.